### PR TITLE
Lowering hooking into wp_head priority to 5

### DIFF
--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -353,4 +353,3 @@ class OneSignal_Public {
   }
 }
 ?>
-

--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -353,3 +353,4 @@ class OneSignal_Public {
   }
 }
 ?>
+

--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -56,7 +56,7 @@ class OneSignal_Public {
   public function __construct() {}
 
   public static function init() {
-    add_action('wp_head', array(__CLASS__, 'onesignal_header'), 1);
+    add_action('wp_head', array(__CLASS__, 'onesignal_header'), 5);
   }
 
   public static function onesignal_header() {

--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -56,7 +56,7 @@ class OneSignal_Public {
   public function __construct() {}
 
   public static function init() {
-    add_action('wp_head', array(__CLASS__, 'onesignal_header'), 5);
+    add_action('wp_head', array(__CLASS__, 'onesignal_header'), 1);
   }
 
   public static function onesignal_header() {


### PR DESCRIPTION
There's absolutely no need in adding OneSignal script to the wp_head
with maximum priority. There's a plugins like Yoast SEO which really
needs to be at the top oh head section.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/64)
<!-- Reviewable:end -->
