### PR TITLE
Fix Issue #106

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -402,8 +402,19 @@ class OneSignal_Admin {
                                     array(__CLASS__, 'admin_menu')
     );
 
+    OneSignal_Admin::save_config_settings_form();
+
     add_action( 'load-' . $OneSignal_menu, array(__CLASS__, 'admin_custom_load') );
-	}
+  }
+
+  public static function save_config_settings_form() {
+    // If the user is trying to save the form, require a valid nonce or die
+    if (array_key_exists('app_id', $_POST)) {
+      // check_admin_referer dies if not valid; no if statement necessary
+      check_admin_referer(OneSignal_Admin::$SAVE_CONFIG_NONCE_ACTION, OneSignal_Admin::$SAVE_CONFIG_NONCE_KEY);
+      $onesignal_wp_settings = OneSignal_Admin::save_config_page($_POST);
+    }
+  }
 
 	public static function admin_menu() {
     require_once( plugin_dir_path( __FILE__ ) . '/views/config.php' );

--- a/views/config.php
+++ b/views/config.php
@@ -7,13 +7,6 @@ if (!OneSignalUtils::can_modify_plugin_settings()) {
   die('Insufficient permissions to access config page.');
 }
 
-// If the user is trying to save the form, require a valid nonce or die
-if (array_key_exists('app_id', $_POST)) {
-  // check_admin_referer dies if not valid; no if statement necessary
-  check_admin_referer(OneSignal_Admin::$SAVE_CONFIG_NONCE_ACTION, OneSignal_Admin::$SAVE_CONFIG_NONCE_KEY);
-  $onesignal_wp_settings = OneSignal_Admin::save_config_page($_POST);
-}
-
 // The user is just viewing the config page; this page cannot be accessed directly
 $onesignal_wp_settings = OneSignal::get_onesignal_settings();
 ?>


### PR DESCRIPTION
Saves the config form before loading settings for the new page view.
This fixes the issue where even after saving the form, the error about
not completing the required fields would appear because the settings for
the new page view were loaded before the previous page's settings were
saved.