### PR TITLE
Php 7.2 compatibility

### DIFF
--- a/onesignal-settings.php
+++ b/onesignal-settings.php
@@ -119,31 +119,31 @@ class OneSignal {
     // Assign defaults if the key doesn't exist in $onesignal_wp_settings
     // Except for those with value CALCULATE_LEGACY_VALUE -- we need special logic for legacy values that used to exist in previous plugin versions
     reset($defaults);
-    while (list($key, $value) = each($defaults)) {
-        if ($value === "CALCULATE_LEGACY_VALUE") {
-            if (!array_key_exists($key, $onesignal_wp_settings)) {
-               $legacyKey = $legacies[$key . '.legacyKey'];
-               $inverted = (array_key_exists($key . '.invertLegacyValue', $legacies) && $legacies[$key . '.invertLegacyValue']);
-               $default = $legacies[$key . '.default'];
-               if (array_key_exists($legacyKey, $onesignal_wp_settings)) {
-                 if ($inverted) {
-                    $onesignal_wp_settings[$key] = !$onesignal_wp_settings[$legacyKey];
-                 } else {
-                    $onesignal_wp_settings[$key] = $onesignal_wp_settings[$legacyKey];
-                 }
-               } else {
-                 $onesignal_wp_settings[$key] = $default;
-               }
-            }
-        }
-        else if ($value === "CALCULATE_SPECIAL_VALUE") {
-	        // Do nothing, handle below
-        }
-        else {
-            if (!array_key_exists($key, $onesignal_wp_settings)) {
-               $onesignal_wp_settings[$key] = $value;
-            }
-        }
+    foreach ($defaults as $key => $value) {
+      if ($value === "CALCULATE_LEGACY_VALUE") {
+          if (!array_key_exists($key, $onesignal_wp_settings)) {
+              $legacyKey = $legacies[$key . '.legacyKey'];
+              $inverted = (array_key_exists($key . '.invertLegacyValue', $legacies) && $legacies[$key . '.invertLegacyValue']);
+              $default = $legacies[$key . '.default'];
+              if (array_key_exists($legacyKey, $onesignal_wp_settings)) {
+                if ($inverted) {
+                  $onesignal_wp_settings[$key] = !$onesignal_wp_settings[$legacyKey];
+                } else {
+                  $onesignal_wp_settings[$key] = $onesignal_wp_settings[$legacyKey];
+                }
+              } else {
+                $onesignal_wp_settings[$key] = $default;
+              }
+          }
+      }
+      else if ($value === "CALCULATE_SPECIAL_VALUE") {
+        // Do nothing, handle below
+      }
+      else {
+          if (!array_key_exists($key, $onesignal_wp_settings)) {
+              $onesignal_wp_settings[$key] = $value;
+          }
+      }
     }
 
     /*

--- a/onesignal-widget.php
+++ b/onesignal-widget.php
@@ -43,6 +43,6 @@ class OneSignalWidget extends WP_Widget {
 	}
 }
 
-add_action('widgets_init', create_function('', 'return register_widget("OneSignalWidget");'));
+add_action('widgets_init', function(){register_widget("OneSignalWidget");});
 
 ?>

--- a/readme.txt
+++ b/readme.txt
@@ -56,7 +56,7 @@ Features:
 
 = 1.16.8 =
 
-This release makes HTTP switch match the dashboard. Renamed to "My site is not fully HTTPS".
+This release makes HTTP switch match the dashboard (renamed to "My site is not fully HTTPS") and removes deprecation warnings for php 7.2.
 
 = 1.16.7 =
 


### PR DESCRIPTION
Same changes as in [PR-130](https://github.com/OneSignal/OneSignal-WordPress-Plugin/pull/130) except removing commented line in onesignal_settings.php:122.

Tested compatibility with previous versions of php (namely 5.5 and 7.0).

Updated change log correspondingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/144)
<!-- Reviewable:end -->
