### PR TITLE
Added timeout to handle edge case

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -252,12 +252,12 @@ class OneSignal_Admin {
        * Unchecks box automatically once post is published
        *    - mitigates issue where users publish, edit, and republish post (duplicate notifications)
        */
-      function uncheckBox(){
+      function handlePostPublish(){
         var willSend = document.getElementsByName("send_onesignal_notification")[0].checked;
         if (willSend && confirm("Publishing post. Are you sure you want to notify your subscribers?")) {
           setTimeout(function(){document.getElementsByName("send_onesignal_notification")[0].checked=!willSend},300);
         } else if (willSend)  {
-          document.getElementsByName("send_onesignal_notification")[0].checked=!willSend;
+          document.getElementsByName("send_onesignal_notification")[0].checked=false;
         }
       }
       
@@ -266,14 +266,15 @@ class OneSignal_Admin {
        */
       var addListeners = function(){
         try{
-          var button = document.getElementsByClassName('editor-post-publish-button')[0];
+          var publishButton = document.getElementsByClassName('editor-post-publish-button')[0];
           
-          if (button) {
-            // publish button exists - add uncheckBox as callback
-            button.addEventListener("click", uncheckBox);
+          if (publishButton) {
+            // publish button exists - add handlePostPublish as callback
+            publishButton.addEventListener("click", handlePostPublish);
           } else {
             // publish button doesn't exist yet - add this function to pre-publish button
-            document.getElementsByClassName('editor-post-publish-panel__toggle')[0].addEventListener("click", function(){setTimeout(addListeners, 300)});
+            var prePublishButton = document.getElementsByClassName('editor-post-publish-panel__toggle')[0];
+            prePublishButton.addEventListener("click", function(){setTimeout(addListeners, 300)});
           }
         } catch(e) {
           console.log(e);

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -254,11 +254,13 @@ class OneSignal_Admin {
        */
       function handlePostPublish(){
         var willSend = document.getElementsByName("send_onesignal_notification")[0].checked;
-        if (willSend && confirm("Publishing post. Are you sure you want to notify your subscribers?")) {
-          setTimeout(function(){document.getElementsByName("send_onesignal_notification")[0].checked=false},300);
+        if (willSend && confirm("OneSignal: publishing post. Are you sure you want to notify your subscribers?\n\nNote: cancelling will still publish your post but won't send notifications")) {
+          setTimeout(function(){document.getElementsByName("send_onesignal_notification")[0].checked=false},600);
         } else if (willSend)  {
           document.getElementsByName("send_onesignal_notification")[0].checked=false;
         }
+        // add event listeners again (wp removes publish button and renders a new one after initial publish)
+        setTimeout(addListeners, 600);
       }
       
       /**
@@ -274,7 +276,7 @@ class OneSignal_Admin {
           } else {
             // publish button doesn't exist yet - add this function to pre-publish button
             var prePublishButton = document.getElementsByClassName('editor-post-publish-panel__toggle')[0];
-            prePublishButton.addEventListener("click", function(){setTimeout(addListeners, 300)});
+            prePublishButton.addEventListener("click", function(){setTimeout(addListeners, 600)});
           }
         } catch(e) {
           console.log(e);

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -255,7 +255,7 @@ class OneSignal_Admin {
       function handlePostPublish(){
         var willSend = document.getElementsByName("send_onesignal_notification")[0].checked;
         if (willSend && confirm("Publishing post. Are you sure you want to notify your subscribers?")) {
-          setTimeout(function(){document.getElementsByName("send_onesignal_notification")[0].checked=!willSend},300);
+          setTimeout(function(){document.getElementsByName("send_onesignal_notification")[0].checked=false},300);
         } else if (willSend)  {
           document.getElementsByName("send_onesignal_notification")[0].checked=false;
         }

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -244,6 +244,45 @@ class OneSignal_Admin {
     onesignal_debug('    [$meta_box_checkbox_send_notification]', 'in_array($post->post_status, array("future", "draft", "auto-draft", "pending"):', in_array($post->post_status, array("future", "draft", "auto-draft", "pending")), '(' . $post->post_status . ')');
 
     ?>
+
+    <!-- code to handle checkbox issue on wordpress 5.0.0+ (may need to modify for future versions of WP)-->
+    <script>
+      /**
+       * Prompt confirmation upon post publish with onesignal checkbox clicked
+       * Unchecks box automatically once post is published
+       *    - mitigates issue where users publish, edit, and republish post (duplicate notifications)
+       */
+      function uncheckBox(){
+        var willSend = document.getElementsByName("send_onesignal_notification")[0].checked;
+        if (willSend && confirm("Publishing post. Are you sure you want to notify your subscribers?")) {
+          setTimeout(function(){document.getElementsByName("send_onesignal_notification")[0].checked=!willSend},300);
+        } else if (willSend)  {
+          document.getElementsByName("send_onesignal_notification")[0].checked=!willSend;
+        }
+      }
+      
+      /**
+       * Mount listeners to publish buttons
+       */
+      var addListeners = function(){
+        try{
+          var button = document.getElementsByClassName('editor-post-publish-button')[0];
+          
+          if (button) {
+            // publish button exists - add uncheckBox as callback
+            button.addEventListener("click", uncheckBox);
+          } else {
+            // publish button doesn't exist yet - add this function to pre-publish button
+            document.getElementsByClassName('editor-post-publish-panel__toggle')[0].addEventListener("click", function(){setTimeout(addListeners, 300)});
+          }
+        } catch(e) {
+          console.log(e);
+        }
+      }
+      
+      window.onload = addListeners;
+    </script>
+    
 	    <input type="hidden" name="onesignal_meta_box_present" value="true"></input>
       <input type="checkbox" name="send_onesignal_notification" value="true" <?php if ($meta_box_checkbox_send_notification) { echo "checked"; } ?>></input>
       <label>


### PR DESCRIPTION
- Edge case where user publishes with push turned on and then edits wanting to push again
- WP was remounting button so this was removing the listener (only after initial publish)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/164)
<!-- Reviewable:end -->
