### PR TITLE
Revert Checkbox JS Code

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -244,48 +244,6 @@ class OneSignal_Admin {
     onesignal_debug('    [$meta_box_checkbox_send_notification]', 'in_array($post->post_status, array("future", "draft", "auto-draft", "pending"):', in_array($post->post_status, array("future", "draft", "auto-draft", "pending")), '(' . $post->post_status . ')');
 
     ?>
-
-    <!-- code to handle checkbox issue on wordpress 5.0.0+ (may need to modify for future versions of WP)-->
-    <script>
-      /**
-       * Prompt confirmation upon post publish with onesignal checkbox clicked
-       * Unchecks box automatically once post is published
-       *    - mitigates issue where users publish, edit, and republish post (duplicate notifications)
-       */
-      function handlePostPublish(){
-        var willSend = document.getElementsByName("send_onesignal_notification")[0].checked;
-
-        if (willSend && confirm("OneSignal: publishing post. Are you sure you want to notify your subscribers?\n\nNote: cancelling will still publish your post but won't send notifications")) {
-          setTimeout(function(){document.getElementsByName("send_onesignal_notification")[0].checked=false},600);
-        } else if (willSend)  {
-          document.getElementsByName("send_onesignal_notification")[0].checked=false;
-        }
-        // add event listeners again (wp removes publish button and renders a new one after initial publish)
-        setTimeout(addListeners, 600);
-      }
-      
-      /**
-       * Mount listeners to publish buttons
-       */
-      var addListeners = function(){
-        try{
-          var publishButton = document.getElementsByClassName('editor-post-publish-button')[0];
-          
-          if (publishButton) {
-            // publish button exists - add handlePostPublish as callback
-            publishButton.addEventListener("click", handlePostPublish);
-          } else {
-            // publish button doesn't exist yet - add this function to pre-publish button
-            var prePublishButton = document.getElementsByClassName('editor-post-publish-panel__toggle')[0];
-            prePublishButton.addEventListener("click", function(){setTimeout(addListeners, 600)});
-          }
-        } catch(e) {
-          console.log(e);
-        }
-      }
-      
-      window.onload = addListeners;
-    </script>
     
 	    <input type="hidden" name="onesignal_meta_box_present" value="true"></input>
       <input type="checkbox" name="send_onesignal_notification" value="true" <?php if ($meta_box_checkbox_send_notification) { echo "checked"; } ?>></input>


### PR DESCRIPTION
- Removed JS code that is causing posts to no longer send notifications for some users
- Left UUID in request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/165)
<!-- Reviewable:end -->
