### PR TITLE
HTTP API migration from cURL

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -527,14 +527,13 @@ public static function uuid($title) {
   * The main function that actually sends a notification to OneSignal.
   */
   public static function send_notification_on_wp_post($new_status, $old_status, $post) {
-    try {
+	try {
 	    if (!function_exists('curl_init')) {
 		    onesignal_debug('Canceling send_notification_on_wp_post because curl_init() is not a defined function.');
 		    return;
 	    }
 
-
-      $time_to_wait = self::get_sending_rate_limit_wait_time();
+      	    $time_to_wait = self::get_sending_rate_limit_wait_time();
 	    if ($time_to_wait > 0) {
             set_transient('onesignal_transient_error', '<div class="error notice onesignal-error-notice">
                     <p><strong>OneSignal Push:</strong><em> Please try again in ' . $time_to_wait . ' seconds. Only one notification can be sent every ' . ONESIGNAL_API_RATE_LIMIT_SECONDS . ' seconds.</em></p>
@@ -667,24 +666,24 @@ public static function uuid($title) {
         }
 
         $fields = array(
-          'external_id'       => self::uuid($notif_content),
-          'app_id'            => $onesignal_wp_settings['app_id'],
-          'headings'          => array("en" => $site_title),
-          'included_segments' => array('All'),
-          'isAnyWeb'          => true,
-          'url'               => get_permalink($post->ID),
-          'contents'          => array("en" => $notif_content)
+          "external_id"       => self::uuid($notif_content),
+          "app_id"            => $onesignal_wp_settings["app_id"],
+          "headings"          => array("en" => $site_title),
+          "included_segments" => array("All"),
+          "isAnyWeb"          => true,
+          "url"               => get_permalink($post->ID),
+          "contents"          => array("en" => $notif_content)
         );
 
         $send_to_mobile_platforms = $onesignal_wp_settings['send_to_mobile_platforms'];
         if ($send_to_mobile_platforms == true) {
-          $fields['isIos'] = true;
-          $fields['isAndroid'] = true;
+          $fields["isIos"] = true;
+          $fields["isAndroid"] = true;
         }
 
-        $config_utm_additional_url_params = $onesignal_wp_settings['utm_additional_url_params'];
+        $config_utm_additional_url_params = $onesignal_wp_settings["utm_additional_url_params"];
         if (!empty($config_utm_additional_url_params)) {
-            $fields['url'] .= '?' . $config_utm_additional_url_params;
+            $fields["url"] .= '?' . $config_utm_additional_url_params;
         }
 
         if (has_post_thumbnail($post->ID)) {
@@ -735,9 +734,6 @@ public static function uuid($title) {
           $out = fopen('php://output', 'w');
         }
 
-	      onesignal_debug('Initializing cURL.');
-        $ch = curl_init();
-
         $onesignal_post_url = "https://onesignal.com/api/v1/notifications";
 
         if (defined('ONESIGNAL_DEBUG') && defined('ONESIGNAL_LOCAL')) {
@@ -746,35 +742,19 @@ public static function uuid($title) {
 
         $onesignal_auth_key = $onesignal_wp_settings['app_rest_api_key'];
 
-        curl_setopt($ch, CURLOPT_URL, $onesignal_post_url);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, array(
-          'Content-Type: application/json',
-          'Authorization: Basic ' . $onesignal_auth_key
-        ));
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_HEADER, false);
-        curl_setopt($ch, CURLOPT_POST, true);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($fields));
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 
-	      if (defined('ONESIGNAL_DEBUG')) {
-		      // Turn off host verification for localhost testing since we're using a self-signed certificate
-		      curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
-	      }
+	$request = array(
+		"headers" => array(
+          		"content-type" => "application/json",
+          		"Authorization" => "Basic " . $onesignal_auth_key
+		),
+		"body" => json_encode($fields)
+	);
 
-	      if (class_exists('WDS_Log_Post')) {
-          curl_setopt($ch, CURLOPT_FAILONERROR, false);
-          curl_setopt($ch, CURLOPT_HTTP200ALIASES, array(400));
-          curl_setopt($ch, CURLOPT_VERBOSE, true);
-          curl_setopt($ch, CURLOPT_STDERR, $out);
-        }
+	$response = wp_remote_post($onesignal_post_url, $request);
 
-        $response = curl_exec($ch);
-
-        $curl_http_code     = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-          onesignal_debug('$curl_http_code:', $curl_http_code);
-        if ($curl_http_code != 200) {
-          if ($curl_http_code != 0) {
+        if ($response['status'] != 200) {
+          if ($response['status'] != 0) {
             set_transient( 'onesignal_transient_error', '<div class="error notice onesignal-error-notice">
                     <p><strong>OneSignal Push:</strong><em> There was a ' . $curl_http_code . ' error sending your notification:</em></p>
                     <pre>' . print_r($response, true) . '</pre>
@@ -798,8 +778,10 @@ public static function uuid($title) {
 
             if ($config_show_notification_send_status_message) {
               if ($recipient_count != 0) {
-                set_transient('onesignal_transient_success', '<div class="updated notice notice-success is-dismissible">
-                        <p><strong>OneSignal Push:</strong><em> Successfully ' . $sent_or_scheduled . ' a notification to ' . $parsed_response['recipients'] . ' recipients.</em></p>
+		      set_transient('onesignal_transient_success', '<div class="components-notice is-success is-dismissible">
+			      <div class="components-notice__content">
+			      <p><strong>OneSignal Push:</strong><em> Successfully ' . $sent_or_scheduled . ' a notification to ' . $parsed_response['recipients'] . ' recipients.</em></p>
+			      </div>
                     </div>', 86400);
               } else {
                 set_transient('onesignal_transient_success', '<div class="updated notice notice-success is-dismissible">
@@ -810,25 +792,11 @@ public static function uuid($title) {
           }
         }
 
-	      if (defined('ONESIGNAL_DEBUG') || class_exists('WDS_Log_Post')) {
+	if (defined('ONESIGNAL_DEBUG') || class_exists('WDS_Log_Post')) {
           fclose($out);
           $debug_output = ob_get_clean();
 
-          $curl_effective_url = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
-          $curl_total_time    = curl_getinfo($ch, CURLINFO_TOTAL_TIME);
-
-          onesignal_debug('OneSignal API POST Data:', $fields);
-          onesignal_debug('OneSignal API URL:', $curl_effective_url);
-          onesignal_debug('OneSignal API Response Status Code:', $curl_http_code);
-	        if ($curl_http_code != 200) {
-		        onesignal_debug('cURL Request Time:', $curl_total_time, 'seconds');
-		        onesignal_debug('cURL Error Number:', curl_errno($ch));
-		        onesignal_debug('cURL Error Description:', curl_error($ch));
-		        onesignal_debug('cURL Response:', print_r($response, true));
-		        onesignal_debug('cURL Verbose Log:', $debug_output);
-	        }
         }
-	      curl_close($ch);
 
         self::update_last_sent_timestamp();
 

--- a/onesignal.php
+++ b/onesignal.php
@@ -6,7 +6,7 @@ defined( 'ABSPATH' ) or die('This page may not be accessed directly.');
  * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description: Free web push notifications.
- * Version: 1.16.12
+ * Version: 1.16.13
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://onesignal.com
 Tags: chrome, firefox, safari, push, push notifications, push notification, chrome push, safari push, firefox push, notification, notifications, web push, notify, mavericks, android, android push, android notifications, android notification, mobile notification, mobile notifications, mobile, desktop notification, roost, goroost, desktop notifications, gcm, push messages, onesignal
 Requires at least: 3.8
 Tested up to: 5.0.3
-Stable tag: 1.16.12
+Stable tag: 1.16.13
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -64,6 +64,10 @@ OneSignal is trusted by over 600,000 developers and marketing strategists. We po
 HTTPS Setup Video: [youtube https://www.youtube.com/watch?v=BeTZ2KgytC0]
 
 == Changelog ==
+
+= 1.16.13 =
+
+- Added timestamp to allow re-pushing notifications upon editing an existing post after 1 hr
 
 = 1.16.12 =
 


### PR DESCRIPTION
- migrated cURL calls to newer HTTP api
- tested backwards compatibility (w/ 4.8)
- fixed delivered count
- TO-DO: fix notices in WP5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/170)
<!-- Reviewable:end -->
