### PR TITLE
Version 1.16.16

### DIFF
--- a/notice.js
+++ b/notice.js
@@ -1,12 +1,9 @@
 jQuery(document).ready(function() {
-  const editor = wp.data.select("core/editor");
-  if (!editor) {
-    console.warn(
-      "OneSignal Push: couldn't load wp.data. https://bit.ly/2F4G0bt"
-    );
-    return;
+  if ( !isWpCoreEditorDefined() ) {
+  	return;
   }
 
+  const editor = wp.data.select("core/editor");
   const get_wp_attr = attr => {
     return editor.getEditedPostAttribute(attr);
   };
@@ -136,4 +133,24 @@ jQuery(document).ready(function() {
       isDismissible: true
     });
   };
+
 });
+const isWpCoreEditorDefined = () => {
+  var unloadable = ""; 	// variable that couldn't be loaded
+  if (!wp || !wp.data || !wp.data.select("core/editor") ) {
+      if ( !wp ) {
+          unloadable = "wp";
+  } else if ( !wp.data ) {
+      unloadable = "wp.data";
+  } else if ( !wp.data.select("core/editor") ) {
+      unloadable = "wp.data.select(\"core/editor\")";
+  }
+
+  console.warn(
+      `OneSignal Push: could not load ${unloadable}. https:\/\/bit.ly/2F4G0bt`
+  );
+  return false;
+} else {
+  return true;
+}
+}

--- a/notice.js
+++ b/notice.js
@@ -1,12 +1,12 @@
 jQuery(document).ready(function() {
-  if (!wp.data) {
+  const editor = wp.data.select("core/editor");
+  if (!editor) {
     console.warn(
       "OneSignal Push: couldn't load wp.data. https://bit.ly/2F4G0bt"
     );
     return;
   }
 
-  const editor = wp.data.select("core/editor");
   const get_wp_attr = attr => {
     return editor.getEditedPostAttribute(attr);
   };

--- a/notice.js
+++ b/notice.js
@@ -1,6 +1,6 @@
 jQuery(document).ready(function() {
-  if ( !isWpCoreEditorDefined() ) {
-  	return;
+  if (!isWpCoreEditorDefined()) {
+    return;
   }
 
   const editor = wp.data.select("core/editor");
@@ -133,24 +133,23 @@ jQuery(document).ready(function() {
       isDismissible: true
     });
   };
-
 });
 const isWpCoreEditorDefined = () => {
-  var unloadable = ""; 	// variable that couldn't be loaded
-  if (!wp || !wp.data || !wp.data.select("core/editor") ) {
-      if ( !wp ) {
-          unloadable = "wp";
-  } else if ( !wp.data ) {
+  var unloadable = ""; // variable that couldn't be loaded
+  if (!wp || !wp.data || !wp.data.select("core/editor")) {
+    if (!wp) {
+      unloadable = "wp";
+    } else if (!wp.data) {
       unloadable = "wp.data";
-  } else if ( !wp.data.select("core/editor") ) {
-      unloadable = "wp.data.select(\"core/editor\")";
-  }
+    } else if (!wp.data.select("core/editor")) {
+      unloadable = 'wp.data.select("core/editor")';
+    }
 
-  console.warn(
+    console.warn(
       `OneSignal Push: could not load ${unloadable}. https:\/\/bit.ly/2F4G0bt`
-  );
-  return false;
-} else {
-  return true;
-}
-}
+    );
+    return false;
+  } else {
+    return true;
+  }
+};

--- a/onesignal.php
+++ b/onesignal.php
@@ -6,7 +6,7 @@ defined( 'ABSPATH' ) or die('This page may not be accessed directly.');
  * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description: Free web push notifications.
- * Version: 1.16.14
+ * Version: 1.16.16
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://onesignal.com
 Tags: chrome, firefox, safari, push, push notifications, push notification, chrome push, safari push, firefox push, notification, notifications, web push, notify, mavericks, android, android push, android notifications, android notification, mobile notification, mobile notifications, mobile, desktop notification, roost, goroost, desktop notifications, gcm, push messages, onesignal
 Requires at least: 3.8
 Tested up to: 5.0.3
-Stable tag: 1.16.15
+Stable tag: 1.16.16
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -64,6 +64,10 @@ OneSignal is trusted by over 600,000 developers and marketing strategists. We po
 HTTPS Setup Video: [youtube https://www.youtube.com/watch?v=BeTZ2KgytC0]
 
 == Changelog ==
+
+= 1.16.16 = 
+
+- Code to catch error where core/editor is not defined for old versions of the editor
 
 = 1.16.15 =
 


### PR DESCRIPTION
Code to catch error where core/editor is not defined for old version of the editor

Many folks complaining that it broke their Yoast plugin (because Javascript threw an error, terminating execution)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/178)
<!-- Reviewable:end -->
