### PR TITLE
Support more detailed error messages

### DIFF
--- a/notice.js
+++ b/notice.js
@@ -68,7 +68,7 @@ jQuery(document).ready(function() {
   
       // status 0: HTTP request failed
       if (status_code == 0) {
-        error_notice("OneSignal Push: HTTP request failed");
+        error_notice("OneSignal Push: request failed. "+error_message);
         reset_state();
 	return;
       }

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -805,8 +805,9 @@ public static function uuid($title) {
 
 	if ( is_wp_error($response) || !is_array( $response ) || !isset( $response['body']) ) {
 		$status = $response->get_error_code(); 				// custom code for WP_ERROR
-		error_log("There was a ".$status." error returned from OneSignal");	
-		update_post_meta($post->ID, "error_message", $response->get_error_message());
+        $error_message = $response->get_error_message();
+        error_log("There was a ".$status." error returned from OneSignal: ".$error_message);	
+		update_post_meta($post->ID, "error_message", $error_message);
         return;
     } 
     

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -803,7 +803,7 @@ public static function uuid($title) {
 
 	$response = wp_remote_post($onesignal_post_url, $request);
 
-	if ( is_wp_error($response) || !is_array( $response ) || !isset( $response['body']) ) {
+    if ( is_wp_error($response) || !is_array( $response ) || !isset( $response['body']) ) {
         $status = $response->get_error_code(); 				// custom code for WP_ERROR
         $error_message = $response->get_error_message();
         error_log("There was a ".$status." error returned from OneSignal: ".$error_message);	

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -804,10 +804,10 @@ public static function uuid($title) {
 	$response = wp_remote_post($onesignal_post_url, $request);
 
 	if ( is_wp_error($response) || !is_array( $response ) || !isset( $response['body']) ) {
-		$status = $response->get_error_code(); 				// custom code for WP_ERROR
+        $status = $response->get_error_code(); 				// custom code for WP_ERROR
         $error_message = $response->get_error_message();
         error_log("There was a ".$status." error returned from OneSignal: ".$error_message);	
-		update_post_meta($post->ID, "error_message", $error_message);
+        update_post_meta($post->ID, "error_message", $error_message);
         return;
     } 
     

--- a/onesignal.php
+++ b/onesignal.php
@@ -6,7 +6,7 @@ defined( 'ABSPATH' ) or die('This page may not be accessed directly.');
  * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description: Free web push notifications.
- * Version: 1.17.0
+ * Version: 1.17.1
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://onesignal.com
 Tags: chrome, firefox, safari, push, push notifications, push notification, chrome push, safari push, firefox push, notification, notifications, web push, notify, mavericks, android, android push, android notifications, android notification, mobile notification, mobile notifications, mobile, desktop notification, roost, goroost, desktop notifications, gcm, push messages, onesignal
 Requires at least: 3.8
 Tested up to: 5.0.3
-Stable tag: 1.17.0
+Stable tag: 1.17.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -64,6 +64,10 @@ OneSignal is trusted by over 600,000 developers and marketing strategists. We po
 HTTPS Setup Video: [youtube https://www.youtube.com/watch?v=BeTZ2KgytC0]
 
 == Changelog ==
+
+= 1.17.1 =
+
+- Support for more detailed error messages
 
 = 1.17.0 =
 


### PR DESCRIPTION
* on Gutenberg: changed failed request message to "request failed:" + <error message>
* on classic editor, error messages are logged to error log

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/184)
<!-- Reviewable:end -->
