### PR TITLE
1.17.3 release (#189)

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -794,7 +794,7 @@ public static function uuid($title) {
 
 
 	$request = array(
-		"headers" => array(
+    "headers" => array(
           		"content-type" => "application/json;charset=utf-8",
           		"Authorization" => "Basic " . $onesignal_auth_key
 		),
@@ -831,8 +831,10 @@ public static function uuid($title) {
 	update_post_meta($post->ID, "status", $status);
 	
 	if ($status != 200) {
+    error_log("There was a ".$status." error sending your notification.");
+    error_log("Response from OneSignal:", json_encode($response));
           if ($status != 0) {	  
-		set_transient( 'onesignal_transient_error', '<div class="error notice onesignal-error-notice">
+		        set_transient( 'onesignal_transient_error', '<div class="error notice onesignal-error-notice">
                     <p><strong>OneSignal Push:</strong><em> There was a ' . $status . ' error sending your notification.</em></p>
                 </div>', 86400 );
           } else {
@@ -865,10 +867,10 @@ public static function uuid($title) {
 
             if ($config_show_notification_send_status_message) {
               if ($recipient_count != 0) {
-		      set_transient('onesignal_transient_success', '<div class="components-notice is-success is-dismissible">
-			      <div class="components-notice__content">
-			      <p><strong>OneSignal Push:</strong><em> Successfully ' . $sent_or_scheduled . ' a notification to ' . $recipient_count . ' recipients.</em></p>
-			      </div>
+                set_transient('onesignal_transient_success', '<div class="components-notice is-success is-dismissible">
+                  <div class="components-notice__content">
+                  <p><strong>OneSignal Push:</strong><em> Successfully ' . $sent_or_scheduled . ' a notification to ' . $recipient_count . ' recipients.</em></p>
+                  </div>
                     </div>', 86400);
               } else {
                 set_transient('onesignal_transient_success', '<div class="updated notice notice-success is-dismissible">

--- a/onesignal.php
+++ b/onesignal.php
@@ -6,7 +6,7 @@ defined( 'ABSPATH' ) or die('This page may not be accessed directly.');
  * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description: Free web push notifications.
- * Version: 1.17.2
+ * Version: 1.17.3
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://onesignal.com
 Tags: chrome, firefox, safari, push, push notifications, push notification, chrome push, safari push, firefox push, notification, notifications, web push, notify, mavericks, android, android push, android notifications, android notification, mobile notification, mobile notifications, mobile, desktop notification, roost, goroost, desktop notifications, gcm, push messages, onesignal
 Requires at least: 3.8
 Tested up to: 5.1
-Stable tag: 1.17.2
+Stable tag: 1.17.3
 
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -22,7 +22,7 @@ You can configure notification delivery at preset intervals, create user segment
 OneSignal is free for up to 30,000 subscribers; there are no limits on the number of push notifications you can send. Contact [support@onesignal.com](mailto:support@onesignal.com) if you have any questions. We’d love to hear from you.
 
 = Company =
-OneSignal is trusted by over 600,000 developers and marketing strategists. We power push notifications for everyone from early stage startups to Fortune 500 Companies, sending 4 billion notifications per day. It is the most popular push notification plugin on Wordpress with 90,000+ installations.
+OneSignal is trusted by over 650,000 developers and marketing strategists. We power push notifications for everyone from early stage startups to Fortune 500 Companies, sending 4 billion notifications per day. It is the most popular push notification plugin on Wordpress with 90,000+ installations.
 
 = Features =
 * **Supports Chrome** (Desktop & Android), **Safari** (Mac OS X), **Microsoft Edge** (Desktop & Android), **Opera** (Desktop & Android) and **Firefox** (Desktop & Android) on both HTTP and HTTPS sites.
@@ -65,6 +65,12 @@ OneSignal is trusted by over 600,000 developers and marketing strategists. We po
 HTTPS Setup Video: [youtube https://www.youtube.com/watch?v=BeTZ2KgytC0]
 
 == Changelog ==
+
+= 1.17.3 =
+
+- Added debug to logging to responses with non 200-level status codes
+- Made notices unique
+- Bug fixes
 
 = 1.17.2 =
 


### PR DESCRIPTION
* Added id to notices to prevent duplicate notices 

* Differentiate between regular notices and error notices when it comes to IDs

* Added debug logging to responses with non-200 level status codes

* refactoring, fixed some comments and bugs

* timeout logic bug

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/190)
<!-- Reviewable:end -->
