### PR TITLE
changed time limit from 1 hour to 2 minutes

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -557,7 +557,7 @@ public static function uuid($title) {
   $prev_minutes = get_option('TimeLastUpdated');
   $prehash = (string)$title; 
 
-  if ($prev_minutes !== false && ($now_minutes - $prev_minutes) > 60) {
+  if ($prev_minutes !== false && ($now_minutes - $prev_minutes) > 2) {
 	update_option('TimeLastUpdated', $now_minutes);
 	$timestamp = $now_minutes;
   } else if ($prev_minutes == false) {


### PR DESCRIPTION
- hope to reduce number of errors showing "there were 0 recipients"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/191)
<!-- Reviewable:end -->
