### PR TITLE
Updated time-limiting error notice to say two minutes instead of 1 hour

### DIFF
--- a/notice.js
+++ b/notice.js
@@ -105,7 +105,7 @@ function notice() {
 
         if (recipients === "0") {
           error_notice(
-            "OneSignal Push: there were no recipients. You either 1) have no subscribers yet or 2) you hit the rate-limit. Please try again in an hour. Learn more: https://bit.ly/2UDplAS"
+            "OneSignal Push: there were no recipients. You either 1) have no subscribers yet or 2) you hit the rate-limit. Please try again in two minutes. Learn more: https://bit.ly/2UDplAS"
           );
           reset_state();
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/196)
<!-- Reviewable:end -->
