### PR TITLE
Removed newline from Readme.txt 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,6 @@ Tags: chrome, firefox, safari, push, push notifications, push notification, chro
 Requires at least: 3.8
 Tested up to: 5.1
 Stable tag: 1.17.4
-
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Was resulting in plugin description looking strange

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/198)
<!-- Reviewable:end -->
