### PR TITLE
Include send_after in API call

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -9,11 +9,6 @@ function onesignal_change_footer_admin() {
  * Loads js script that includes ajax call with post id
  */
 
-add_action('transition_post_status', 'schedule_function', '10',1);
-function schedule_function(){
-    error_log('SCHEDULED');
-}
-
 add_action('admin_enqueue_scripts', 'load_javascript');
 function load_javascript() {
 	global $post;
@@ -817,7 +812,6 @@ public static function uuid($title) {
 	);
 
 	$response = wp_remote_post($onesignal_post_url, $request);
-	error_log('RESPONSE '.json_encode($response));
     if ( is_wp_error($response) || !is_array( $response ) || !isset( $response['body']) ) {
         $status = $response->get_error_code(); 				// custom code for WP_ERROR
         $error_message = $response->get_error_message();
@@ -915,19 +909,16 @@ public static function uuid($title) {
   }
 
   public static function on_transition_post_status( $new_status, $old_status, $post ) {
-    error_log("ON_TRANSITION".get_post_status($post)." ".$new_status." ".$old_status);	  
     if ($post->post_type == 'wdslp-wds-log' || self::was_post_restored_from_trash($old_status, $new_status)) {
         // It's important not to call onesignal_debug() on posts of type wdslp-wds-log, otherwise each post will recursively generate 4 more posts
         return;
     }
     if ($new_status == "future") {
-      error_log("FUTURE QUEUED");	    
       self::send_notification_on_wp_post($new_status, $old_status, $post);
       return;
     }
 
     if (has_filter('onesignal_include_post')) {
-      error_log("Applying INCLUDE");	  
       onesignal_debug('Applying onesignal_include_post filter.');
       if (apply_filters('onesignal_include_post', $new_status, $old_status, $post)) {
           // If the filter returns "$do_include_post: true", always process this post
@@ -939,7 +930,6 @@ public static function uuid($title) {
 
 
     if (has_filter('onesignal_exclude_post')) {
-      error_log("Applying EXCLUDE");	  
       onesignal_debug('Applying onesignal_exclude_post filter.');
       if (apply_filters('onesignal_exclude_post', $new_status, $old_status, $post)) {
           // If the filter returns "$do_exclude_post: false", do not process this post at all

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -887,7 +887,7 @@ public static function uuid($title) {
                     </div>', 86400);
               } else {
                 set_transient('onesignal_transient_success', '<div class="updated notice notice-success is-dismissible">
-                        <p><strong>OneSignal Push:</strong><em>There were no recipients. You either 1) have no subscribers yet or 2) you hit the rate-limit. Please try again in an hour.</em></p>
+                        <p><strong>OneSignal Push:</strong><em>There were no recipients. You either 1) have no subscribers yet or 2) you hit the rate-limit. Please try again in three minutes. Learn more: https://bit.ly/2UDplAS </em></p>
                     </div>', 86400);
               }
             }

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -714,15 +714,15 @@ public static function uuid($title) {
             onesignal_debug('Caught qTrans exception:', $e->getMessage());
           }
         }
-	
-	$post_time = get_post_time('D M d Y G:i:', true, $post);
+  
+        $post_time = get_post_time('D M d Y G:i:', true, $post);
 
-  if(!$post_time){
-		error_log("OneSignal: Couldn't get post_time");
-		return;
-	} else {
-	   $post_time = $post_time."00 GMT-0:00";
-	}
+        if(!$post_time){
+          error_log("OneSignal: Couldn't get post_time");
+          return;
+        } else {
+          $post_time = $post_time."00 GMT-0:00";
+        }
 	
         $fields = array(
           "external_id"       => self::uuid($notif_content),

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -716,8 +716,8 @@ public static function uuid($title) {
         }
 	
 	$post_time = get_post_time('D M d Y G:i:', true, $post);
-	error_log("ERROR_LOG:".$post_time);
-	if(!$post_time){
+
+  if(!$post_time){
 		error_log("OneSignal: Couldn't get post_time");
 		return;
 	} else {
@@ -913,6 +913,7 @@ public static function uuid($title) {
         // It's important not to call onesignal_debug() on posts of type wdslp-wds-log, otherwise each post will recursively generate 4 more posts
         return;
     }
+
     if ($new_status == "future") {
       self::send_notification_on_wp_post($new_status, $old_status, $post);
       return;
@@ -928,7 +929,6 @@ public static function uuid($title) {
       }
     }
 
-
     if (has_filter('onesignal_exclude_post')) {
       onesignal_debug('Applying onesignal_exclude_post filter.');
       if (apply_filters('onesignal_exclude_post', $new_status, $old_status, $post)) {
@@ -937,11 +937,11 @@ public static function uuid($title) {
           return;
       }
     }
+
     if (!(empty($post) ||
         $new_status !== "publish" ||
         $post->post_type == 'page')) {
         self::send_notification_on_wp_post($new_status, $old_status, $post);
-        error_log("Applying ELSE");	  
     }
   }
 }


### PR DESCRIPTION
- Get the post's scheduled time, convert to GMT, pass into the send_after param in the API call
- Update to `notice.js` to trigger Gutenberg js with `"future"` post statuses (Post is scheduled)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/200)
<!-- Reviewable:end -->
