### PR TITLE
1.17.9 Release Commit

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -756,7 +756,7 @@ class OneSignal_Admin
 
                     return;
                 } else {
-                    $post_time = $post_time.'00 GMT-0:00';
+                    $post_time = $post_time.'30 GMT-0:00';
                 }
 
                 $old_uuid_array = get_post_meta($post->ID, 'uuid');

--- a/onesignal.php
+++ b/onesignal.php
@@ -6,7 +6,7 @@ defined( 'ABSPATH' ) or die('This page may not be accessed directly.');
  * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description: Free web push notifications.
- * Version: 1.17.8
+ * Version: 1.17.9
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://onesignal.com
 Tags: chrome, firefox, safari, push, push notifications, push notification, chrome push, safari push, firefox push, notification, notifications, web push, notify, mavericks, android, android push, android notifications, android notification, mobile notification, mobile notifications, mobile, desktop notification, roost, goroost, desktop notifications, gcm, push messages, onesignal
 Requires at least: 3.8
 Tested up to: 5.2.1
-Stable tag: 1.17.8
+Stable tag: 1.17.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -64,6 +64,10 @@ OneSignal is trusted by over 708,000 developers and marketing strategists. We po
 HTTPS Setup Video: [youtube https://www.youtube.com/watch?v=BeTZ2KgytC0]
 
 == Changelog ==
+
+= 1.17.9 =
+
+- Added 30 second delay to scheduled notifications
 
 = 1.17.8 =
 


### PR DESCRIPTION
Added 30 second delay to scheduled notifications #207

The reason is that some servers would take a lot of time publishing a post. This resulted in folks clicking notifications to posts that aren't published yet, showing a 404.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/207)
<!-- Reviewable:end -->
