### PR TITLE
1.17.9 Release Commit

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -757,6 +757,8 @@ class OneSignal_Admin
 
                     return;
                 } else {
+                    // delays scheduled notifications by 30 seconds
+                    // slow-to-publish servers would result in 404's since the notification went out faster, this should fix the problem 
                     $post_time = $post_time.'30 GMT-0:00';
                 }
 

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -584,7 +584,7 @@ class OneSignal_Admin
      * @title - title of post
      * return - uuid of sha1 hash of post title + post timestamp
      */
-    public static function uuid($title)
+    public static function uuid($title, $time)
     {
         $now = explode(':', date('z:H:i'));
         $now_minutes = $now[0] * 60 * 24 + $now[1] * 60 + $now[2];
@@ -601,7 +601,8 @@ class OneSignal_Admin
             $timestamp = $prev_minutes;
         }
 
-        $prehash = $prehash.$timestamp;
+        // hash will be a function of the title, last updated time, and scheduled post time
+        $prehash = $prehash.$timestamp.$time;
 
         $sha1 = substr(sha1($prehash), 0, 32);
 
@@ -756,11 +757,11 @@ class OneSignal_Admin
 
                     return;
                 } else {
-                    $post_time = $post_time.'00 GMT-0:00';
+                    $post_time = $post_time.'30 GMT-0:00';
                 }
 
                 $old_uuid_array = get_post_meta($post->ID, 'uuid');
-                $uuid = self::uuid($notif_content);
+                $uuid = self::uuid($notif_content, $post_time);
                 update_post_meta($post->ID, 'uuid', $uuid);
 
                 $fields = array(
@@ -772,12 +773,12 @@ class OneSignal_Admin
                   'url' => get_permalink($post->ID),
                   'contents' => array('en' => $notif_content),
                 );
-                
+
                 if ($new_status == 'future') {
                     if ($old_uuid_array && $old_uuid_array[0] != $uuid) {
                         self::cancel_scheduled_notification($post);
                     }
-                    
+
                     $fields['send_after'] = $post_time;
                 }
 

--- a/onesignal.php
+++ b/onesignal.php
@@ -1,36 +1,34 @@
 <?php
 
-defined( 'ABSPATH' ) or die('This page may not be accessed directly.');
+defined('ABSPATH') or die('This page may not be accessed directly.');
 
-/**
+/*
  * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description: Free web push notifications.
- * Version: 1.17.8
+ * Version: 1.17.9
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT
  */
 
-define( 'ONESIGNAL_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+define('ONESIGNAL_PLUGIN_URL', plugin_dir_url(__FILE__));
 
-/**
+/*
  * The number of seconds required to wait between requests.
  */
-define( 'ONESIGNAL_API_RATE_LIMIT_SECONDS', 1 );
-define( 'ONESIGNAL_URI_REVEAL_PROJECT_NUMBER', 'reveal_project_number=true' );
+define('ONESIGNAL_API_RATE_LIMIT_SECONDS', 1);
+define('ONESIGNAL_URI_REVEAL_PROJECT_NUMBER', 'reveal_project_number=true');
 
-require_once( plugin_dir_path( __FILE__ ) . 'onesignal-utils.php' );
-require_once( plugin_dir_path( __FILE__ ) . 'onesignal-admin.php' );
-require_once( plugin_dir_path( __FILE__ ) . 'onesignal-public.php' );
-require_once( plugin_dir_path( __FILE__ ) . 'onesignal-settings.php' );
-require_once( plugin_dir_path( __FILE__ ) . 'onesignal-widget.php' );
+require_once plugin_dir_path(__FILE__).'onesignal-utils.php';
+require_once plugin_dir_path(__FILE__).'onesignal-admin.php';
+require_once plugin_dir_path(__FILE__).'onesignal-public.php';
+require_once plugin_dir_path(__FILE__).'onesignal-settings.php';
+require_once plugin_dir_path(__FILE__).'onesignal-widget.php';
 
-if (file_exists(plugin_dir_path( __FILE__ ) . 'onesignal-extra.php')) {
-    require_once( plugin_dir_path( __FILE__ ) . 'onesignal-extra.php' );
+if (file_exists(plugin_dir_path(__FILE__).'onesignal-extra.php')) {
+    require_once plugin_dir_path(__FILE__).'onesignal-extra.php';
 }
 
-add_action( 'init', array( 'OneSignal_Admin', 'init' ) );
-add_action( 'init', array( 'OneSignal_Public', 'init' ) );
-
-?>
+add_action('init', array('OneSignal_Admin', 'init'));
+add_action('init', array('OneSignal_Public', 'init'));

--- a/readme.txt
+++ b/readme.txt
@@ -65,6 +65,10 @@ HTTPS Setup Video: [youtube https://www.youtube.com/watch?v=BeTZ2KgytC0]
 
 == Changelog ==
 
+= 1.17.9 =
+
+- Added 30 second delay to scheduled notification send time, bug fixes
+
 = 1.17.8 =
 
 - Added escaping to fields in OneSignal config to remove invalid characters, bug fixes

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://onesignal.com
 Tags: chrome, firefox, safari, push, push notifications, push notification, chrome push, safari push, firefox push, notification, notifications, web push, notify, mavericks, android, android push, android notifications, android notification, mobile notification, mobile notifications, mobile, desktop notification, roost, goroost, desktop notifications, gcm, push messages, onesignal
 Requires at least: 3.8
 Tested up to: 5.2.1
-Stable tag: 1.17.8
+Stable tag: 1.17.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
- Added 30 second delay to scheduled notification send time
- Bug fix: added post time as input to idempotency hash function 
   - Reason: previously didn't cancel first scheduled notification when the second was scheduled since it thought it was the same

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/208)
<!-- Reviewable:end -->
