### PR TITLE
Fix for deprecated create_function

### DIFF
--- a/onesignal-widget.php
+++ b/onesignal-widget.php
@@ -43,6 +43,7 @@ class OneSignalWidget extends WP_Widget {
 	}
 }
 
-add_action('widgets_init', function(){register_widget("OneSignalWidget");});
-
-?>
+function onesignal_register_widgets() {
+	register_widget("OneSignalWidget");
+}
+add_action('widgets_init', 'onesignal_register_widgets' );


### PR DESCRIPTION
create_function is deprecated in PHP. Continued use in this plugin is blowing up PHP error logs with PHP deprecation notices.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/216)
<!-- Reviewable:end -->

