### PR TITLE
Add Nonce Verification to `send_notification_on_wp_post` and fix `on_save_post`

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -609,6 +609,15 @@ class OneSignal_Admin
                 return;
             }
 
+	        // Verify that the nonce is valid.            
+            if (!wp_verify_nonce((
+                isset($_POST[OneSignal_Admin::$SAVE_POST_NONCE_KEY]) ? 
+                sanitize_text_field($_POST[OneSignal_Admin::$SAVE_POST_NONCE_KEY]) : 
+                ''
+            ), OneSignal_Admin::$SAVE_POST_NONCE_ACTION)) {
+		        return;
+            }
+
             $time_to_wait = self::get_sending_rate_limit_wait_time();
             if ($time_to_wait > 0) {
                 set_transient('onesignal_transient_error', '<div class="error notice onesignal-error-notice">
@@ -631,20 +640,6 @@ class OneSignal_Admin
             $onesignal_meta_box_present = $was_posted && isset($_POST['onesignal_meta_box_present'], $_POST['onesignal_meta_box_present']) && $_POST['onesignal_meta_box_present'] === 'true';
             /* The checkbox "Send notification on post publish/update" on the OneSignal meta box is checked */
             $onesignal_meta_box_send_notification_checked = $was_posted && array_key_exists('send_onesignal_notification', $_POST) && $_POST['send_onesignal_notification'] === 'true';
-
-            if (!$onesignal_meta_box_send_notification_checked) {
-                return;
-            }
-	    
-	        // Verify that the nonce is valid.            
-            if (!wp_verify_nonce((
-                isset($_POST[OneSignal_Admin::$SAVE_POST_NONCE_KEY]) ? 
-                sanitize_text_field($_POST[OneSignal_Admin::$SAVE_POST_NONCE_KEY]) : 
-                ''
-            ), OneSignal_Admin::$SAVE_POST_NONCE_ACTION)) {
-		        return;
-            }
-
             /* This is a scheduled post and the OneSignal meta box was present. */
             $post_metadata_was_onesignal_meta_box_present = (get_post_meta($post->ID, 'onesignal_meta_box_present') === true);
             /* This is a scheduled post and the user checked "Send a notification on post publish/update". */

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -190,7 +190,7 @@ class OneSignal_Admin
         /* Some WordPress environments seem to be inconsistent about whether on_save_post is called before transition_post_status
            * Check flag in case we just sent a notification for this post (this on_save_post is called after a successful send)
           */
-        $just_sent_notification = (get_post_meta($post_id, 'onesignal_notification_already_sent') === true);
+        $just_sent_notification = (get_post_meta($post_id, 'onesignal_notification_already_sent', true) === true);
 
         if ($just_sent_notification) {
             // Reset our flag

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -642,9 +642,9 @@ class OneSignal_Admin
             /* The checkbox "Send notification on post publish/update" on the OneSignal meta box is checked */
             $onesignal_meta_box_send_notification_checked = $was_posted && array_key_exists('send_onesignal_notification', $_POST) && $_POST['send_onesignal_notification'] === 'true';
             /* This is a scheduled post and the OneSignal meta box was present. */
-            $post_metadata_was_onesignal_meta_box_present = (get_post_meta($post->ID, 'onesignal_meta_box_present') === true);
+            $post_metadata_was_onesignal_meta_box_present = (get_post_meta($post->ID, 'onesignal_meta_box_present', true) === '1');
             /* This is a scheduled post and the user checked "Send a notification on post publish/update". */
-            $post_metadata_was_send_notification_checked = (get_post_meta($post->ID, 'onesignal_send_notification') === true);
+            $post_metadata_was_send_notification_checked = (get_post_meta($post->ID, 'onesignal_send_notification', true) === '1');
 
             /* Either we were just posted from the WordPress post editor form, or this is a scheduled notification and it was previously submitted from the post editor form */
             $posted_from_wordpress_editor = $onesignal_meta_box_present || $post_metadata_was_onesignal_meta_box_present;

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -160,11 +160,11 @@ class OneSignal_Admin
             return;
         }
         /*
-             * We need to verify this came from the our screen and with proper authorization,
-             * because save_post can be triggered at other times.
-             */
+         * We need to verify this came from the our screen and with proper authorization,
+         * because save_post can be triggered at other times.
+         */
         // Check if our nonce is set.
-        if (isset($_POST[OneSignal_Admin::$SAVE_POST_NONCE_KEY])) {
+        if (!isset($_POST[OneSignal_Admin::$SAVE_POST_NONCE_KEY])) {
             // This is called on every new post ... not necessary to log it.
             return $post_id;
         }

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -609,8 +609,11 @@ class OneSignal_Admin
                 return;
             }
 
+            /* Returns true if there is POST data */
+            $was_posted = !empty($_POST);
+
 	        // Verify that the nonce is valid.            
-            if (!wp_verify_nonce((
+            if ($was_posted && !wp_verify_nonce((
                 isset($_POST[OneSignal_Admin::$SAVE_POST_NONCE_KEY]) ? 
                 sanitize_text_field($_POST[OneSignal_Admin::$SAVE_POST_NONCE_KEY]) : 
                 ''
@@ -633,8 +636,6 @@ class OneSignal_Admin
 
             /* Settings related to creating a post involving the WordPress editor displaying the OneSignal meta box
              **********************************************************************************************************/
-            /* Returns true if there is POST data */
-            $was_posted = !empty($_POST);
 
             /* When this post was created or updated, the OneSignal meta box in the WordPress post editor screen was visible */
             $onesignal_meta_box_present = $was_posted && isset($_POST['onesignal_meta_box_present'], $_POST['onesignal_meta_box_present']) && $_POST['onesignal_meta_box_present'] === 'true';

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -185,20 +185,6 @@ class OneSignal_Admin
             return $post_id;
         }
 
-        /* OK, it's safe for us to save the data now. */
-
-        /* Some WordPress environments seem to be inconsistent about whether on_save_post is called before transition_post_status
-           * Check flag in case we just sent a notification for this post (this on_save_post is called after a successful send)
-          */
-        $just_sent_notification = (get_post_meta($post_id, 'onesignal_notification_already_sent', true) === true);
-
-        if ($just_sent_notification) {
-            // Reset our flag
-            update_post_meta($post_id, 'onesignal_notification_already_sent', false);
-
-            return;
-        }
-
         if (array_key_exists('onesignal_meta_box_present', $_POST)) {
             update_post_meta($post_id, 'onesignal_meta_box_present', true);
         } else {


### PR DESCRIPTION
### `on_save_post`
Nonce was being set to a boolean (used `isset`)

### `send_notification_on_wp_post`
Adds nonce verification

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/228)
<!-- Reviewable:end -->
