### PR TITLE
Minor bug fixes: native_prompt setting & checkbox logic for custom post statuses

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -272,13 +272,14 @@ class OneSignal_Admin
         $settings_send_notification_on_wp_editor_post = $onesignal_wp_settings['notification_on_post'];
 
         /* This is a scheduled post and the user checked "Send a notification on post publish/update". */
-        $post_metadata_was_send_notification_checked = (get_post_meta($post->ID, 'onesignal_send_notification') === true);
-
-        // We check the checkbox if: setting is enabled on Config page, post type is ONLY "post", and the post has not been published (new posts are status "auto-draft")
-        $meta_box_checkbox_send_notification = ($settings_send_notification_on_wp_editor_post &&  // If setting is enabled
-                                            $post->post_type === 'post' &&  // Post type must be type post for checkbox to be auto-checked
-                                            in_array($post->post_status, array('future', 'draft', 'auto-draft', 'pending'), true)) || // Post is scheduled, incomplete, being edited, or is awaiting publication
-                                            ($post_metadata_was_send_notification_checked);
+        if ((get_post_meta($post->ID, 'onesignal_send_notification', true) === '1')) {
+            $meta_box_checkbox_send_notification = true;
+        } else {
+            // We check the checkbox if: setting is enabled on Config page, post type is ONLY "post", and the post has not been published (new posts are status "auto-draft")
+            $meta_box_checkbox_send_notification = ($settings_send_notification_on_wp_editor_post &&  // If setting is enabled
+                                                $post->post_type === 'post' &&  // Post type must be type post for checkbox to be auto-checked
+                                                !in_array($post->post_status, array('publish', 'private', 'trash', 'inherit'), true)); // Post is scheduled, incomplete, being edited, or is awaiting publication
+        }
 
         if (has_filter('onesignal_meta_box_send_notification_checkbox_state')) {
             $meta_box_checkbox_send_notification = apply_filters('onesignal_meta_box_send_notification_checkbox_state', $post, $onesignal_wp_settings);

--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -287,11 +287,11 @@ class OneSignal_Public
                 <?php
             }
         
-            if ($onesignal_wp_settings['prompt_auto_register'] === true) {
+            if (array_key_exists('prompt_auto_register', $onesignal_wp_settings) && $onesignal_wp_settings['prompt_auto_register'] === true) {
                     echo "OneSignal.showSlidedownPrompt();";
             }
 
-            if ($onesignal_wp_settings['use_native_prompt'] === true) {
+            if (array_key_exists('use_native_prompt', $onesignal_wp_settings) && $onesignal_wp_settings['use_native_prompt'] === true) {
                 echo "OneSignal.showNativePrompt();";
             }
         

--- a/onesignal.php
+++ b/onesignal.php
@@ -6,7 +6,7 @@ defined('ABSPATH') or die('This page may not be accessed directly.');
  * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description: Free web push notifications.
- * Version: 2.1.0
+ * Version: 2.1.1
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://onesignal.com
 Tags: chrome, firefox, safari, push, push notifications, push notification, chrome push, safari push, firefox push, notification, notifications, web push, notify, mavericks, android, android push, android notifications, android notification, mobile notification, mobile notifications, mobile, desktop notification, roost, goroost, desktop notifications, gcm, push messages, onesignal
 Requires at least: 3.8
 Tested up to: 5.3.2
-Stable tag: 2.1.0
+Stable tag: 2.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -64,6 +64,10 @@ OneSignal is trusted by over 860,000 developers and marketing strategists. We po
 HTTPS Setup Video: [youtube https://www.youtube.com/watch?v=BeTZ2KgytC0]
 
 == Changelog ==
+
+= 2.1.1 =
+
+- Minor bug fixes: check native_prompt setting key exists, reworked checkbox logic to support custom post statuses
 
 = 2.1.0 = 
 


### PR DESCRIPTION
Minor bug fixes: 
- check native_prompt setting key exists
- reworked checkbox logic to support custom post statuses

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/236)
<!-- Reviewable:end -->
