### PR TITLE
Only show the last 4 chars of the REST API key

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -431,10 +431,12 @@ class OneSignal_Admin
         foreach ($settings as $setting) {
             $value = sanitize_text_field($config[$setting]);
 
-            // app_rest_api_key will be empty if the user did not try to change the value
-            // This prevents it from being cleared
-            if ($setting === 'app_rest_api_key' && empty($value))
-                continue;
+            if ($setting === 'app_rest_api_key') {
+                // Only save key if the value has been changed.
+                // This prevents its masked value from becoming the value saved to the DB
+                if (OneSignal::maskedRestApiKey($onesignal_wp_settings[$setting]) === $value)
+                    continue;
+            }
 
             $onesignal_wp_settings[$setting] = $value;
         }

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -406,9 +406,6 @@ class OneSignal_Admin
       'allowed_custom_post_types',
       'notification_title',
       'custom_manifest_url',
-      'http_permission_request_modal_title',
-      'http_permission_request_modal_message',
-      'http_permission_request_modal_button_text',
       'persist_notifications',
     );
         OneSignal_Admin::saveStringSettings($onesignal_wp_settings, $config, $stringSettings);
@@ -439,9 +436,7 @@ class OneSignal_Admin
             if ($setting === 'app_rest_api_key' && empty($value))
                 continue;
 
-            if (array_key_exists($setting, $config)) {
-                $onesignal_wp_settings[$setting] = $value;
-            }
+            $onesignal_wp_settings[$setting] = $value;
         }
     }
 

--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -432,9 +432,14 @@ class OneSignal_Admin
     public static function saveStringSettings(&$onesignal_wp_settings, &$config, $settings)
     {
         foreach ($settings as $setting) {
+            $value = sanitize_text_field($config[$setting]);
+
+            // app_rest_api_key will be empty if the user did not try to change the value
+            // This prevents it from being cleared
+            if ($setting === 'app_rest_api_key' && empty($value))
+                continue;
+
             if (array_key_exists($setting, $config)) {
-                $value = $config[$setting];
-                $value = sanitize_text_field($value);
                 $onesignal_wp_settings[$setting] = $value;
             }
         }

--- a/onesignal-settings.php
+++ b/onesignal-settings.php
@@ -87,9 +87,6 @@ class OneSignal {
                   'use_custom_sdk_init' => false,
                   'show_notification_send_status_message' => true,
                   'use_http_permission_request' => 'CALCULATE_SPECIAL_VALUE',
-                  'http_permission_request_modal_title' => '',
-                  'http_permission_request_modal_message' => '',
-                  'http_permission_request_modal_button_text' => '',
                   'persist_notifications' => 'CALCULATE_SPECIAL_VALUE'
                   );
 

--- a/onesignal-settings.php
+++ b/onesignal-settings.php
@@ -261,4 +261,8 @@ class OneSignal {
     $onesignal_wp_settings = $settings;
     update_option("OneSignalWPSetting", $onesignal_wp_settings);
   }
+
+  public static function maskedRestApiKey($rest_api_key) {
+    return str_repeat('*', 44) . substr($rest_api_key, -4);
+  }
 }

--- a/views/config.php
+++ b/views/config.php
@@ -9,6 +9,17 @@ if (!OneSignalUtils::can_modify_plugin_settings()) {
 
 // The user is just viewing the config page; this page cannot be accessed directly
 $onesignal_wp_settings = OneSignal::get_onesignal_settings();
+
+// Shows a example key format if value has not been set yet.
+// Or show the last 4 of the API key if it is set.
+// Ensure the OneSignal config page never gets the full key for security
+function formatAPIKeyForPlaceholderView($rest_api_key) {
+  if (empty($rest_api_key))
+    return "Example: " . str_repeat('x', 48);
+
+  return str_repeat('*', 44) . substr($rest_api_key, -4);
+}
+
 ?>
 
 <header class="onesignal">
@@ -289,7 +300,7 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
           </div>
           <div class="field">
             <label>REST API Key<i class="tiny circular help icon link" role="popup" data-title="Rest API Key" data-content="Your 48 character alphanumeric REST API Key. You can find this in App Settings > Keys & IDs." data-variation="wide"></i></label>
-            <input type="text" name="app_rest_api_key" placeholder="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" value="<?php echo esc_attr($onesignal_wp_settings['app_rest_api_key']); ?>">
+            <input type="text" name="app_rest_api_key" placeholder="<?php echo esc_attr(formatAPIKeyForPlaceholderView($onesignal_wp_settings['app_rest_api_key'])); ?>">
           </div>
           <div class="field subdomain-feature">
             <label>OneSignal Label<i class="tiny circular help icon link" role="popup" data-title="Subdomain" data-content="The label you chose for your site. You can find this in Step 2. Wordpress Site Setup" data-variation="wide"></i></label>

--- a/views/config.php
+++ b/views/config.php
@@ -10,16 +10,6 @@ if (!OneSignalUtils::can_modify_plugin_settings()) {
 // The user is just viewing the config page; this page cannot be accessed directly
 $onesignal_wp_settings = OneSignal::get_onesignal_settings();
 
-// Shows a example key format if value has not been set yet.
-// Or show the last 4 of the API key if it is set.
-// Ensure the OneSignal config page never gets the full key for security
-function formatAPIKeyForPlaceholderView($rest_api_key) {
-  if (empty($rest_api_key))
-    return "Example: " . str_repeat('x', 48);
-
-  return str_repeat('*', 44) . substr($rest_api_key, -4);
-}
-
 ?>
 
 <header class="onesignal">
@@ -300,7 +290,7 @@ function formatAPIKeyForPlaceholderView($rest_api_key) {
           </div>
           <div class="field">
             <label>REST API Key<i class="tiny circular help icon link" role="popup" data-title="Rest API Key" data-content="Your 48 character alphanumeric REST API Key. You can find this in App Settings > Keys & IDs." data-variation="wide"></i></label>
-            <input type="text" name="app_rest_api_key" placeholder="<?php echo esc_attr(formatAPIKeyForPlaceholderView($onesignal_wp_settings['app_rest_api_key'])); ?>">
+            <input type="text" name="app_rest_api_key" placeholder="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" value="<?php echo esc_attr(OneSignal::maskedRestApiKey($onesignal_wp_settings['app_rest_api_key'])); ?>">
           </div>
           <div class="field subdomain-feature">
             <label>OneSignal Label<i class="tiny circular help icon link" role="popup" data-title="Subdomain" data-content="The label you chose for your site. You can find this in Step 2. Wordpress Site Setup" data-variation="wide"></i></label>


### PR DESCRIPTION
* This prevents anyone from copying the key from settings that should not have view access to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/240)
<!-- Reviewable:end -->
