### PR TITLE
Prevent notifying updates for non-public post types

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -666,6 +666,11 @@ class OneSignal_Admin
                 $do_send_notification = $non_editor_post_publish_do_send_notification;
             }
 
+            // Prevent notifying updates for non-public post types.
+            if ( ! is_post_type_viewable( $post->post_type ) ) {
+	            $do_send_notification = false;
+            }
+
             if (has_filter('onesignal_include_post')) {
                 if (apply_filters('onesignal_include_post', $new_status, $old_status, $post)) {
                     $do_send_notification = true;


### PR DESCRIPTION
A user reported an issue for the official AMP plugin where the OneSignal plugin was sending out push notifications for updates to the non-public `amp_validated_url` post type: https://github.com/ampproject/amp-wp/issues/5297

When the AMP plugin's Developer Tools are enabled, each save for a post will trigger a loopback request to check the AMP validity of the post on the frontend. The results are then stored in an [`amp_validated_url` post type](https://github.com/ampproject/amp-wp/blob/3e538606f336c1138ee3ef213f8e0efbf14bb4a8/includes/validation/class-amp-validated-url-post-type.php#L161-L199). While this post type is private, the posts are stored with the `publish` status. Nevertheless, they cannot be viewed on the frontend. 

OneSignal is incorrectly detecting updates to the published `amp_validated_url` posts as needing push notifications. This likely is an issue for other post types in WordPress, including core's `customize_changeset` and `nav_menu_item` post types.

In looking at the logic in `\OneSignal_Admin::send_notification_on_wp_post()` I see no checks for whether the post type being saved is actually public, in particular when `$posted_from_wordpress_editor` is true.

This PR should offer a quick way to prevent this from happening.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/251)
<!-- Reviewable:end -->
