### PR TITLE
2.1.4 Release

### DIFF
--- a/onesignal.php
+++ b/onesignal.php
@@ -6,7 +6,7 @@ defined('ABSPATH') or die('This page may not be accessed directly.');
  * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description: Free web push notifications.
- * Version: 2.1.3
+ * Version: 2.1.4
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT
@@ -30,5 +30,5 @@ if (file_exists(plugin_dir_path(__FILE__).'onesignal-extra.php')) {
     require_once plugin_dir_path(__FILE__).'onesignal-extra.php';
 }
 
-add_action('init', array('OneSignal_Admin', 'init'));
-add_action('init', array('OneSignal_Public', 'init'));
+add_action('init', ['OneSignal_Admin', 'init']);
+add_action('init', ['OneSignal_Public', 'init']);

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://onesignal.com
 Tags: push notification, push notifications, desktop notifications, mobile notifications, chrome push, android, android notification, android notifications, android push, desktop notification, firefox, firefox push, mobile, mobile notification, notification, notifications, notify, onesignal, push, push messages, safari, safari push, web push, chrome
 Requires at least: 3.8
 Tested up to: 5.5
-Stable tag: 2.1.3
+Stable tag: 2.1.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,7 +23,7 @@ You can configure notification delivery at preset intervals, create user segment
 OneSignal’s free plan allows targeting up to 30,000 subscribers with push notifications. Contact support@onesignal.com if you have any questions. We’d love to hear from you!
 
 = Company =
-OneSignal is trusted by over 1,030,155 developers and marketing strategists. We power push notifications for everyone from early stage startups to Fortune 500 Companies, sending over 6 billion notifications per day. It is the most popular push notification plugin on Wordpress with 100,000+ installations.
+OneSignal is trusted by over 1,043,856 developers and marketing strategists. We power push notifications for everyone from early stage startups to Fortune 500 Companies, sending over 6 billion notifications per day. It is the most popular push notification plugin on Wordpress with 100,000+ installations.
 
 = Features =
 * **Supports Chrome** (Desktop & Android), **Safari** (Mac OS X), **Microsoft Edge** (Desktop & Android), **Opera** (Desktop & Android) and **Firefox** (Desktop & Android) on both HTTP and HTTPS sites.
@@ -66,6 +66,10 @@ OneSignal is trusted by over 1,030,155 developers and marketing strategists. We 
 HTTPS Setup Video: [youtube https://www.youtube.com/watch?v=BeTZ2KgytC0]
 
 == Changelog ==
+
+= 2.1.4 =
+
+- Bug fix: adds check to prevent notifications for non-public post types
 
 = 2.1.3 =
 


### PR DESCRIPTION
Includes changes from #251 

Prevent notifying updates for non-public post types
- Previously notifications were sent for non-public post types like `amp_validated_url`, `customize_changeset`, or `nav_menu_item`
- This change uses Wordpress API method `is_post_type_viewable` from WP 4.4 to make sure it is viewable before sending

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/252)
<!-- Reviewable:end -->
