### PR TITLE
Bug fix & ability to override content when drafting a post

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -311,7 +311,7 @@ class OneSignal_Admin
       </div>
       <label>
       <div id="onesignal_custom_contents_preferences">
-        <input type="checkbox" id="onesignal_modify_title_and_content" name="onesignal_modify_title_and_content"></input> Customize notification content</label>
+        <input type="checkbox" id="onesignal_modify_title_and_content" value="true" name="onesignal_modify_title_and_content"></input> Customize notification content</label>
           
         <div id="onesignal_custom_contents" style="display:none;padding-top:10px">
           <div>

--- a/sdk_files/index.html
+++ b/sdk_files/index.html
@@ -1,0 +1,2 @@
+<!-- Prevent search bots from indexing this folder if directory listing is enabled on the server -->
+<html><head><meta name="robots" content="noindex, nofollow"></head><body></body></html>

--- a/views/index.html
+++ b/views/index.html
@@ -1,0 +1,2 @@
+<!-- Prevent search bots from indexing this folder if directory listing is enabled on the server -->
+<html><head><meta name="robots" content="noindex, nofollow"></head><body></body></html>


### PR DESCRIPTION
1. Adds index.html file with noindex directives.

By default, Apache webservers have directory listing enabled.

Since we have a path to one of these directories in the javascript code for the plugin, these directories end up getting indexed by google search or other crawlers.

These index files will override any directory listing behavior of Apache, and then the meta tag for noindex will prevent these files themselves from getting indexed by web crawlers.

1. Adds support for overriding the content and heading of a post.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/253)
<!-- Reviewable:end -->

