### PR TITLE
Bump supported wordpress version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
    wordpress:
      depends_on:
        - db
-     image: wordpress:latest
+     image: wordpress:5.6
      ports:
        - "${WORDPRESS_HTTP_PORT}:80"
      restart: always

--- a/onesignal.php
+++ b/onesignal.php
@@ -6,7 +6,7 @@ defined('ABSPATH') or die('This page may not be accessed directly.');
  * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description: Free web push notifications.
- * Version: 2.1.4
+ * Version: 2.1.5
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: OneSignal
 Donate link: https://onesignal.com
 Tags: push notification, push notifications, desktop notifications, mobile notifications, chrome push, android, android notification, android notifications, android push, desktop notification, firefox, firefox push, mobile, mobile notification, notification, notifications, notify, onesignal, push, push messages, safari, safari push, web push, chrome
 Requires at least: 3.8
-Tested up to: 5.5
-Stable tag: 2.1.4
+Tested up to: 5.6
+Stable tag: 2.1.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,10 @@ OneSignal is trusted by over 1,043,856 developers and marketing strategists. We 
 HTTPS Setup Video: [youtube https://www.youtube.com/watch?v=BeTZ2KgytC0]
 
 == Changelog ==
+
+= 2.1.5 =
+
+- Update of "Tested up to" value (WP 5.6). Removed unnecessary jQuery. Includes support for customizing the title and body of notifications. Fixed formatting issues related to apostrophe use.
 
 = 2.1.4 =
 


### PR DESCRIPTION
# Test Plan
A set of functional tests were conducted after running through both the upgrade and install flows.

## Upgrade Flow
1. Follow the steps in PluginDevDockerUsage.md, using a pre-5.6 WP image with the OneSignal plugin already configured
1. Run through WP upgrade flow in the admin panel Web UI
1. Conduct tests below

## Install Flow
1. Follow the steps in PluginDevDockerUsage.md with patch applied.
1. Create a new OS app and configure the OneSignal plugin with the new app id and api key
1. Enable auto prompting
1. Subscribe 
1. Conduct tests below

## Test Cases
1. Config change
1. Test auto-send notif on post, using checkbox
1. Test scheduled notif send on post
1. Test custom post types
1. Test bell render & interactivity


## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/260)
<!-- Reviewable:end -->

