### PR TITLE
Removal of unnecessary jQuery as OneSignalSDK dependency

### DIFF
--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -55,10 +55,10 @@ class OneSignal_Public
     add_filter('clean_url', 'add_async_for_script', 11, 1);
 
     if (defined('ONESIGNAL_DEBUG') && defined('ONESIGNAL_LOCAL')) {
-        wp_register_script('local_sdk', 'https://localhost:3001/sdks/OneSignalSDK.js#asyncload', array('jquery'), false, true);
+        wp_register_script('local_sdk', 'https://localhost:3001/sdks/OneSignalSDK.js#asyncload', array(), false, true);
         wp_enqueue_script('local_sdk');
     } else {
-        wp_register_script('remote_sdk', 'https://cdn.onesignal.com/sdks/OneSignalSDK.js#asyncload', array('jquery'), false, true);
+        wp_register_script('remote_sdk', 'https://cdn.onesignal.com/sdks/OneSignalSDK.js#asyncload', array(), false, true);
         wp_enqueue_script('remote_sdk');
     } ?>
     <script>


### PR DESCRIPTION
OneSignalSDK is written in Vanilla JS and doesn't need jQuery, so there's no point in loading it - it's an extra load on pages that don't use jQuery.
Removing unnecessary scripts improves the [Lighthouse](https://web.dev/measure/) score.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/261)
<!-- Reviewable:end -->

