### PR TITLE
fixed apostrophe issue and small ui update to custom push metabox

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -313,32 +313,27 @@ class OneSignal_Admin
       <div id="onesignal_custom_contents_preferences">
         <input type="checkbox" id="onesignal_modify_title_and_content" value="true" name="onesignal_modify_title_and_content"></input> Customize notification content</label>
           
-        <div id="onesignal_custom_contents" style="display:none;padding-top:10px">
+        <div id="onesignal_custom_contents" style="display:none;padding-top:10px;">
           <div>
             <label>Notification Title<br/>
-            <input type="text" size="16" style="width:250px;" name="onesignal_notification_custom_heading" id="onesignal_notification_custom_heading"></input>
+            <input type="text" size="16" style="width:220px;" name="onesignal_notification_custom_heading" id="onesignal_notification_custom_heading" placeholder="<?php echo esc_attr(OneSignalUtils::decode_entities($onesignal_wp_settings['notification_title'])); ?>"></input>
             </label>
           </div>
-          <div>
+          <div style="padding-top:10px">
             <label>Notification Text<br/>
-            <input type="text" size="16" style="width:250px;" name="onesignal_notification_custom_content" id="onesignal_notification_custom_content"></input>
+            <input type="text" size="16" style="width:220px;" name="onesignal_notification_custom_content" id="onesignal_notification_custom_content" placeholder="The Post's Current Title"></input>
             </label>
           </div>
         </div>
       </div>
 
       <script>
-        var title = "<?php echo esc_attr($site_title); ?>";
         jQuery('#onesignal_modify_title_and_content').change( function() {
             if(jQuery(this).is(":checked")) {              
               jQuery('#onesignal_custom_contents').show();
-              if(!jQuery('#onesignal_notification_custom_heading').val()) {
-                jQuery('#onesignal_notification_custom_heading').val(title);
-              }
               if(!jQuery('#onesignal_notification_custom_content').val()) {
-                jQuery('#onesignal_notification_custom_content').val(jQuery("#title").val())
+                jQuery('#onesignal_notification_custom_content').val(jQuery("#title").val());
               }
-
             } else {
               jQuery('#onesignal_custom_contents').hide();
             }          
@@ -810,11 +805,11 @@ class OneSignal_Admin
                 $fields = array(
                     'external_id' => self::uuid($notif_content),
                     'app_id' => $onesignal_wp_settings['app_id'],
-                    'headings' => array('en' => $site_title),
+                    'headings' => array('en' => stripslashes_deep($site_title)),
                     'included_segments' => array('All'),
                     'isAnyWeb' => true,
                     'url' => get_permalink($post->ID),
-                    'contents' => array('en' => $notif_content),
+                    'contents' => array('en' => stripslashes_deep($notif_content)),
                 );
 
                 $send_to_mobile_platforms = $onesignal_wp_settings['send_to_mobile_platforms'];

--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -82,6 +82,7 @@ class OneSignal_Public
         <?php
         echo "oneSignal_options['wordpress'] = true;\n";
         echo "oneSignal_options['appId'] = '".esc_html($onesignal_wp_settings['app_id'])."';\n";
+        echo "oneSignal_options['allowLocalhostAsSecureOrigin'] = true;\n";
 
         if (array_key_exists('use_http_permission_request', $onesignal_wp_settings) && $onesignal_wp_settings['use_http_permission_request'] === true) {
             echo "oneSignal_options['httpPermissionRequest'] = { };\n";
@@ -119,34 +120,34 @@ class OneSignal_Public
         echo "oneSignal_options['promptOptions'] = { };\n";
         if (array_key_exists('prompt_customize_enable', $onesignal_wp_settings) && $onesignal_wp_settings['prompt_customize_enable'] === true) {
             if (self::valid_for_key('prompt_action_message', $onesignal_wp_settings)) {
-                echo "oneSignal_options['promptOptions']['actionMessage'] = '".esc_html($onesignal_wp_settings['prompt_action_message'])."';\n";
+                echo "oneSignal_options['promptOptions']['actionMessage'] = \"".OneSignalUtils::decode_entities(esc_html($onesignal_wp_settings["prompt_action_message"]))."\";\n"; 
             }
             if (self::valid_for_key('prompt_example_notification_title_desktop', $onesignal_wp_settings)) {
-                echo "oneSignal_options['promptOptions']['exampleNotificationTitleDesktop'] = '".esc_html($onesignal_wp_settings['prompt_example_notification_title_desktop'])."';\n";
+                echo "oneSignal_options['promptOptions']['exampleNotificationTitleDesktop'] = \"".OneSignalUtils::decode_entities(esc_html($onesignal_wp_settings['prompt_example_notification_title_desktop']))."\";\n";
             }
             if (self::valid_for_key('prompt_example_notification_message_desktop', $onesignal_wp_settings)) {
-                echo "oneSignal_options['promptOptions']['exampleNotificationMessageDesktop'] = '".esc_html($onesignal_wp_settings['prompt_example_notification_message_desktop'])."';\n";
+                echo "oneSignal_options['promptOptions']['exampleNotificationMessageDesktop'] = \"".OneSignalUtils::decode_entities(esc_html($onesignal_wp_settings['prompt_example_notification_message_desktop']))."\";\n";
             }
             if (self::valid_for_key('prompt_example_notification_title_mobile', $onesignal_wp_settings)) {
-                echo "oneSignal_options['promptOptions']['exampleNotificationTitleMobile'] = '".esc_html($onesignal_wp_settings['prompt_example_notification_title_mobile'])."';\n";
+                echo "oneSignal_options['promptOptions']['exampleNotificationTitleMobile'] = \"".OneSignalUtils::decode_entities(esc_html($onesignal_wp_settings['prompt_example_notification_title_mobile']))."\";\n";
             }
             if (self::valid_for_key('prompt_example_notification_message_mobile', $onesignal_wp_settings)) {
-                echo "oneSignal_options['promptOptions']['exampleNotificationMessageMobile'] = '".esc_html($onesignal_wp_settings['prompt_example_notification_message_mobile'])."';\n";
+                echo "oneSignal_options['promptOptions']['exampleNotificationMessageMobile'] = \"".OneSignalUtils::decode_entities(esc_html($onesignal_wp_settings['prompt_example_notification_message_mobile']))."\";\n";
             }
             if (self::valid_for_key('prompt_example_notification_caption', $onesignal_wp_settings)) {
-                echo "oneSignal_options['promptOptions']['exampleNotificationCaption'] = '".esc_html($onesignal_wp_settings['prompt_example_notification_caption'])."';\n";
+                echo "oneSignal_options['promptOptions']['exampleNotificationCaption'] = \"".OneSignalUtils::decode_entities(esc_html($onesignal_wp_settings['prompt_example_notification_caption']))."\";\n";
             }
             if (self::valid_for_key('prompt_accept_button_text', $onesignal_wp_settings)) {
-                echo "oneSignal_options['promptOptions']['acceptButtonText'] = '".esc_html($onesignal_wp_settings['prompt_accept_button_text'])."';\n";
+                echo "oneSignal_options['promptOptions']['acceptButtonText'] = \"".OneSignalUtils::decode_entities(esc_html($onesignal_wp_settings['prompt_accept_button_text']))."\";\n";
             }
             if (self::valid_for_key('prompt_cancel_button_text', $onesignal_wp_settings)) {
-                echo "oneSignal_options['promptOptions']['cancelButtonText'] = '".esc_html($onesignal_wp_settings['prompt_cancel_button_text'])."';\n";
+                echo "oneSignal_options['promptOptions']['cancelButtonText'] = \"".OneSignalUtils::decode_entities(esc_html($onesignal_wp_settings['prompt_cancel_button_text']))."\";\n";
             }
             if (self::valid_for_key('prompt_site_name', $onesignal_wp_settings)) {
-                echo "oneSignal_options['promptOptions']['siteName'] = '".esc_html($onesignal_wp_settings['prompt_site_name'])."';\n";
+                echo "oneSignal_options['promptOptions']['siteName'] = \"".OneSignalUtils::decode_entities(esc_html($onesignal_wp_settings['prompt_site_name']))."\";\n";
             }
             if (self::valid_for_key('prompt_auto_accept_title', $onesignal_wp_settings)) {
-                echo "oneSignal_options['promptOptions']['autoAcceptTitle'] = '".esc_html($onesignal_wp_settings['prompt_auto_accept_title'])."';\n";
+                echo "oneSignal_options['promptOptions']['autoAcceptTitle'] = \"".OneSignalUtils::decode_entities(esc_html($onesignal_wp_settings['prompt_auto_accept_title']))."\";\n";
             }
         }
 

--- a/onesignal-settings.php
+++ b/onesignal-settings.php
@@ -253,8 +253,8 @@ class OneSignal {
         }
       }
     }
-
-    return apply_filters( 'onesignal_get_settings', $onesignal_wp_settings );
+    $onesignal_settings_values_without_slashes = stripslashes_deep($onesignal_wp_settings);
+    return apply_filters( 'onesignal_get_settings', $onesignal_settings_values_without_slashes );
   }
 
   public static function save_onesignal_settings($settings) {


### PR DESCRIPTION
## The Problem:
The customer adds apostrophe to any field in the OneSignal settings:
<img width="1300" alt="screen_shot_2021-01-14_at_2 32 33_pm" src="https://user-images.githubusercontent.com/11739227/104657768-2cf8ab00-5687-11eb-9e19-4512b60479d8.png">

Upon save, a slash gets added before the apostrophes. This happens on every save which leads to a buildup of slashes.

<img width="354" alt="Screen Shot 2021-01-14 at 2 33 09 PM" src="https://user-images.githubusercontent.com/11739227/104657761-2a965100-5687-11eb-95bc-52e475ad4f33.png">

These slashes show up on the prompt and the apostrophe gets translated to HTML version:

<img width="602" alt="Screen Shot 2021-01-14 at 2 33 35 PM" src="https://user-images.githubusercontent.com/11739227/104657756-2702ca00-5687-11eb-8b1a-8025ef0e6ff5.png">

## Solution

The following two methods are needed together in order for the fix to work:

`stripslashes_deep` was added to remove slashes automatically added upon saving with an apostrophe. It does not remove slashes added purposely e.g: in UTM params. a side-effect of this workaround is that the apostrophe is converted to HTML version: `&#039` which is why the next function is also needed.

`decode_entities` was added because without it, apostrophes would show up as the HTML version: `&#039;`. This function was previously used elsewhere in the plugin.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/262)
<!-- Reviewable:end -->

