### PR TITLE
Fix use of customized content on scheduled posts

### DIFF
--- a/onesignal.php
+++ b/onesignal.php
@@ -13,7 +13,6 @@ defined('ABSPATH') or die('This page may not be accessed directly.');
  */
 
 define('ONESIGNAL_PLUGIN_URL', plugin_dir_url(__FILE__));
-
 /*
  * The number of seconds required to wait between requests.
  */


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/264)
<!-- Reviewable:end -->

