### PR TITLE
Wordpress - Move off SW root scope

### DIFF
--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -72,15 +72,15 @@ class OneSignal_Public
              * Ex. It will give you a string like this:
              * /wp-content/plugins/onesignal-free-web-push-notifications/
              */
-            $path = strstr(plugin_dir_url(__FILE__), '/wp-content');
-            if(array_key_exists('onesignal_sw_js', $onesignal_wp_settings)) {
-               echo  "OneSignal.SERVICE_WORKER_UPDATER_PATH = 'OneSignalSDKUpdaterWorker.js';
+            if(array_key_exists('onesignal_sw_js', $onesignal_wp_settings)) {         
+                $path = strstr(plugin_dir_url(__FILE__), '/wp-content');
+                echo  "OneSignal.SERVICE_WORKER_UPDATER_PATH = 'OneSignalSDKUpdaterWorker.js';
                       OneSignal.SERVICE_WORKER_PATH = 'OneSignalSDKWorker.js';
                       OneSignal.SERVICE_WORKER_PARAM = { scope: '$path'+'sdk_files/push/onesignal/' };";
             } else {
                 echo 'OneSignal.SERVICE_WORKER_UPDATER_PATH = "OneSignalSDKUpdaterWorker.js.php";
                       OneSignal.SERVICE_WORKER_PATH = "OneSignalSDKWorker.js.php";
-                      OneSignal.SERVICE_WORKER_PARAM = { scope: "push/onesignal" };';
+                      OneSignal.SERVICE_WORKER_PARAM = { scope: "/" };';
             }
         ?>
 

--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -66,9 +66,23 @@ class OneSignal_Public
       window.OneSignal = window.OneSignal || [];
 
       OneSignal.push( function() {
-        OneSignal.SERVICE_WORKER_UPDATER_PATH = "OneSignalSDKUpdaterWorker.js.php";
-        OneSignal.SERVICE_WORKER_PATH = "OneSignalSDKWorker.js.php";
-        OneSignal.SERVICE_WORKER_PARAM = { scope: '/' };
+        <?php
+            /**
+             * strstr method will remove the unecessary path before /wp-content
+             * Ex. It will give you a string like this:
+             * /wp-content/plugins/onesignal-free-web-push-notifications/
+             */
+            $path = strstr(plugin_dir_url(__FILE__), '/wp-content');
+            if(array_key_exists('onesignal_sw_js', $onesignal_wp_settings)) {
+               echo  "OneSignal.SERVICE_WORKER_UPDATER_PATH = 'OneSignalSDKUpdaterWorker.js';
+                      OneSignal.SERVICE_WORKER_PATH = 'OneSignalSDKWorker.js';
+                      OneSignal.SERVICE_WORKER_PARAM = { scope: '$path'+'sdk_files/push/onesignal/' };";
+            } else {
+                echo 'OneSignal.SERVICE_WORKER_UPDATER_PATH = "OneSignalSDKUpdaterWorker.js.php";
+                      OneSignal.SERVICE_WORKER_PATH = "OneSignalSDKWorker.js.php";
+                      OneSignal.SERVICE_WORKER_PARAM = { scope: "push/onesignal" };';
+            }
+        ?>
 
         <?php
         if (self::valid_for_key('default_url', $onesignal_wp_settings)) {

--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -67,12 +67,12 @@ class OneSignal_Public
 
       OneSignal.push( function() {
         <?php
-            /**
-             * strstr method will remove the unecessary path before /wp-content
-             * Ex. It will give you a string like this:
-             * /wp-content/plugins/onesignal-free-web-push-notifications/
-             */
-            if(array_key_exists('onesignal_sw_js', $onesignal_wp_settings)) {         
+            if(array_key_exists('onesignal_sw_js', $onesignal_wp_settings)) {
+                 /**
+                 * strstr method will remove the unecessary path before /wp-content
+                 * Ex. It will give you a string like this:
+                 * /wp-content/plugins/onesignal-free-web-push-notifications/
+                 */         
                 $path = strstr(plugin_dir_url(__FILE__), '/wp-content');
                 echo  "OneSignal.SERVICE_WORKER_UPDATER_PATH = 'OneSignalSDKUpdaterWorker.js';
                       OneSignal.SERVICE_WORKER_PATH = 'OneSignalSDKWorker.js';

--- a/onesignal-settings.php
+++ b/onesignal-settings.php
@@ -88,7 +88,10 @@ class OneSignal {
                   'show_notification_send_status_message' => true,
                   'use_http_permission_request' => 'CALCULATE_SPECIAL_VALUE',
                   'persist_notifications' => 'CALCULATE_SPECIAL_VALUE',
-                  'onesignal_sw_js' => true
+                  /*
+                   * 'onesignal_sw_js' => true -> this is false people who
+                   *  upgraded from version 2.1.7
+                   */
                   );
 
     $legacies = array(
@@ -106,12 +109,21 @@ class OneSignal {
     $onesignal_wp_settings = get_option("OneSignalWPSetting");
     if (empty( $onesignal_wp_settings )) {
         $is_new_user = true;
+        $defaults['onesignal_sw_js'] = true;
         $onesignal_wp_settings = array();
     }
 
     // Assign defaults if the key doesn't exist in $onesignal_wp_settings
     // Except for those with value CALCULATE_LEGACY_VALUE -- we need special logic for legacy values that used to exist in previous plugin versions
     reset($defaults);
+
+    /*
+    * 'onesignal_sw_js' => true -> for new users
+    */
+    if ($is_new_user) {
+      $defaults['onesignal_sw_js'] = true;
+    }
+
     foreach ($defaults as $key => $value) {
       if ($value === "CALCULATE_LEGACY_VALUE") {
           if (!array_key_exists($key, $onesignal_wp_settings)) {

--- a/onesignal-settings.php
+++ b/onesignal-settings.php
@@ -88,6 +88,7 @@ class OneSignal {
                   'show_notification_send_status_message' => true,
                   'use_http_permission_request' => 'CALCULATE_SPECIAL_VALUE',
                   'persist_notifications' => 'CALCULATE_SPECIAL_VALUE'
+                  'onesignal_sw_js' => true
                   );
 
     $legacies = array(

--- a/onesignal-settings.php
+++ b/onesignal-settings.php
@@ -109,7 +109,6 @@ class OneSignal {
     $onesignal_wp_settings = get_option("OneSignalWPSetting");
     if (empty( $onesignal_wp_settings )) {
         $is_new_user = true;
-        $defaults['onesignal_sw_js'] = true;
         $onesignal_wp_settings = array();
     }
 

--- a/onesignal-settings.php
+++ b/onesignal-settings.php
@@ -87,7 +87,7 @@ class OneSignal {
                   'use_custom_sdk_init' => false,
                   'show_notification_send_status_message' => true,
                   'use_http_permission_request' => 'CALCULATE_SPECIAL_VALUE',
-                  'persist_notifications' => 'CALCULATE_SPECIAL_VALUE'
+                  'persist_notifications' => 'CALCULATE_SPECIAL_VALUE',
                   'onesignal_sw_js' => true
                   );
 

--- a/sdk_files/OneSignalSDKUpdaterWorker.js
+++ b/sdk_files/OneSignalSDKUpdaterWorker.js
@@ -1,0 +1,1 @@
+importScripts('https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js');

--- a/sdk_files/OneSignalSDKWorker.js
+++ b/sdk_files/OneSignalSDKWorker.js
@@ -1,0 +1,1 @@
+importScripts('https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js');


### PR DESCRIPTION
OneSignal’s ServiceWorker defaults to a root scope which may create the following issues for your site:

- Conflict with a PWA
- Conflict with an AMP setup
- Conflict with your caching ServiceWorker, or any other ServiceWorker feature that requires root scope
- Your site has security requirements that do not allow third-party ServiceWorker code to run on a scope that controls a pages your users will visit.




**If you are using an other plugin that may require the usage of a service worker, please install that plugin first, then install the OneSignal plugin after.**

What was tested:

-Existing users that update to a newer version of the plugin

<img width="673" alt="Screen Shot 2021-03-25 at 6 59 19 PM" src="https://user-images.githubusercontent.com/11162114/112666519-a56fab00-8e32-11eb-96e5-1b0613c341cd.png">

-New install of the OneSignal plugin

<img width="754" alt="Screen Shot 2021-03-25 at 12 39 47 PM" src="https://user-images.githubusercontent.com/11162114/112509877-47c25c80-8d67-11eb-9c7c-faac3f436b77.png">

-New OneSignal install with an existing plugin that requieres the usage of a service worker





Ticket: https://app.asana.com/0/1200001281475104/1199993616956902

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/268)
<!-- Reviewable:end -->

