### PR TITLE
hotfix(js): missing OneSignalSDKWorker.js file added

### DIFF
--- a/onesignal.php
+++ b/onesignal.php
@@ -6,7 +6,7 @@ defined('ABSPATH') or die('This page may not be accessed directly.');
  * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description: Free web push notifications.
- * Version: 2.2.0
+ * Version: 2.2.1
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://onesignal.com
 Tags: push notification, push notifications, desktop notifications, mobile notifications, chrome push, android, android notification, android notifications, android push, desktop notification, firefox, firefox push, mobile, mobile notification, notification, notifications, notify, onesignal, push, push messages, safari, safari push, web push, chrome
 Requires at least: 3.8
 Tested up to: 5.7
-Stable tag: 2.2.0
+Stable tag: 2.2.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,10 @@ OneSignal is trusted by over 1,189,788 developers and marketing strategists. We 
 HTTPS Setup Video: [youtube https://www.youtube.com/watch?v=BeTZ2KgytC0]
 
 == Changelog ==
+
+= 2.2.1 =
+
+- Fixes error for missing OneSignalSDKWorker.js file
 
 = 2.2.0 =
 


### PR DESCRIPTION
Fixes error of missing file in version 2.2.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/271)
<!-- Reviewable:end -->
