### PR TITLE
Fix sw scope for non wp-content Wordpress setups

### DIFF
--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -39,6 +39,16 @@ class OneSignal_Public
         return false;
     }
 
+    // Returns the OneSignal plugin URL path
+    // Examples:
+    //   /wp-content/plugins/onesignal-free-web-push-notifications
+    //   /app/plugins/onesignal-free-web-push-notifications
+    private static function getOneSignalPluginPath()
+    {
+        $path = parse_url(ONESIGNAL_PLUGIN_URL)['path'];
+        return rtrim($path, '/');
+    }
+
     public static function onesignal_header()
     {
         $onesignal_wp_settings = OneSignal::get_onesignal_settings();
@@ -68,15 +78,10 @@ class OneSignal_Public
       OneSignal.push( function() {
         <?php
             if(array_key_exists('onesignal_sw_js', $onesignal_wp_settings)) {
-                 /**
-                 * strstr method will remove the unecessary path before /wp-content
-                 * Ex. It will give you a string like this:
-                 * /wp-content/plugins/onesignal-free-web-push-notifications/
-                 */         
-                $path = strstr(plugin_dir_url(__FILE__), '/wp-content');
+                $swScope = self::getOneSignalPluginPath() . '/sdk_files/push/onesignal/';
                 echo  "OneSignal.SERVICE_WORKER_UPDATER_PATH = 'OneSignalSDKUpdaterWorker.js';
                       OneSignal.SERVICE_WORKER_PATH = 'OneSignalSDKWorker.js';
-                      OneSignal.SERVICE_WORKER_PARAM = { scope: '$path'+'sdk_files/push/onesignal/' };";
+                      OneSignal.SERVICE_WORKER_PARAM = { scope: '$swScope' };";
             } else {
                 echo 'OneSignal.SERVICE_WORKER_UPDATER_PATH = "OneSignalSDKUpdaterWorker.js.php";
                       OneSignal.SERVICE_WORKER_PATH = "OneSignalSDKWorker.js.php";


### PR DESCRIPTION
## Description
### One Line summary
Fix ServiceWorker scope path for Wordpress setups that do not use "wp-content" as part of their app. Example such as [Bedrock](https://github.com/roots/bedrock).


## Details
* Some Wordpress setups (such as roots/bedrock) use "app"
instead of "wp-content" as URL path.
* Instead of assuming "wp-content" is present we always use the full
path URL.
   - Created a `getOneSignalPluginPath` function to generate the path
   without the domain to provide this.


## Tested
* Standard Wordpress 5.7
* [presslabs/wordpress-runtime:bedrock docker image](https://www.presslabs.com/docs/stack/how-to/development/local-development-with-bedrock/) w/ Wordpress 5.7 to ensure it works end-to-end.

## Related
* PR - [Move off SW root scope for new installs #268](https://github.com/OneSignal/OneSignal-WordPress-Plugin/pull/268)
* Issue - [Installing service worker failed (non wp-content directory structure) #273](https://github.com/OneSignal/OneSignal-WordPress-Plugin/issues/273)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/275)
<!-- Reviewable:end -->
