### PR TITLE
Adds support for Yoast Duplicate Post Plugin

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -847,6 +847,14 @@ class OneSignal_Admin
                     'contents' => array('en' => stripslashes_deep($notif_content)),
                 );
 
+                // Support for: https://yoast.com/wordpress/plugins/duplicate-post/
+                // Rewrite post url to the original url if current post is a duplicate post revision
+                $dp_is_revision = (int)get_post_meta($post->ID, '_dp_is_rewrite_republish_copy', true) === 1;
+                $dp_original_post_id = (int)get_post_meta($post->ID, '_dp_original', true);
+                if($dp_is_revision === true && $dp_original_post_id > 0) {
+                    $fields['url'] = get_permalink($dp_original_post_id);
+                }
+
                 $send_to_mobile_platforms = $onesignal_wp_settings['send_to_mobile_platforms'];
                 if ($send_to_mobile_platforms === true) {
                     $fields['isIos'] = true;


### PR DESCRIPTION
As discussed in #279 this should add support for Yoast Duplicate Post Plugin. If a message is send it will check if the current posts is a revision of duplicate post plugin and fetches the original post id. Then the permalink of the current post getting published is overwritten with the permalink from the orignal post the revision points to.

Closes #279 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/280)
<!-- Reviewable:end -->
