### PR TITLE
Fix/sanitize custom notification fields

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -202,8 +202,8 @@ class OneSignal_Admin
 
         if (array_key_exists('onesignal_modify_title_and_content', $_POST)) {
             update_post_meta($post_id, 'onesignal_modify_title_and_content', true);
-            update_post_meta($post_id, 'onesignal_notification_custom_heading', $_POST['onesignal_notification_custom_heading']);
-            update_post_meta($post_id, 'onesignal_notification_custom_content', $_POST['onesignal_notification_custom_content']);
+            update_post_meta($post_id, 'onesignal_notification_custom_heading', sanitize_text_field($_POST['onesignal_notification_custom_heading']));
+            update_post_meta($post_id, 'onesignal_notification_custom_content', sanitize_text_field($_POST['onesignal_notification_custom_content']));
         } else {
             update_post_meta($post_id, 'onesignal_modify_title_and_content', false);
             update_post_meta($post_id, 'onesignal_notification_custom_heading', null);
@@ -717,15 +717,15 @@ class OneSignal_Admin
 
             // If this post is newly being created and if the user has chosen to customize the content
             $onesignal_customized_content = $onesignal_customize_content_checked || (get_post_meta($post->ID, 'onesignal_modify_title_and_content', true) === '1');
-          
-            if($was_posted && $onesignal_customized_content) {                
-                $onesignal_custom_notification_heading = $_POST['onesignal_notification_custom_heading'];
-                $onesignal_custom_notification_content = $_POST['onesignal_notification_custom_content'];
-            } else { // If this post was created previously (eg: scheduled), and the user had chosen to customize the content                
+
+            if($was_posted && $onesignal_customized_content) {
+                $onesignal_custom_notification_heading = sanitize_text_field($_POST['onesignal_notification_custom_heading']);
+                $onesignal_custom_notification_content = sanitize_text_field($_POST['onesignal_notification_custom_content']);
+            } else { // If this post was created previously (eg: scheduled), and the user had chosen to customize the content
                 $onesignal_custom_notification_heading = get_post_meta($post->ID, 'onesignal_notification_custom_heading', true);
                 $onesignal_custom_notification_content = get_post_meta($post->ID, 'onesignal_notification_custom_content', true);
             }
-            
+
             /* This is a scheduled post and the OneSignal meta box was present. */
             $post_metadata_was_onesignal_meta_box_present = (get_post_meta($post->ID, 'onesignal_meta_box_present', true) === '1');
             /* This is a scheduled post and the user checked "Send a notification on post publish/update". */
@@ -840,11 +840,11 @@ class OneSignal_Admin
                 $fields = array(
                     'external_id' => self::uuid($notif_content),
                     'app_id' => $onesignal_wp_settings['app_id'],
-                    'headings' => array('en' => stripslashes_deep($site_title)),
+                    'headings' => array('en' => stripslashes_deep(wp_specialchars_decode($site_title))),
                     'included_segments' => array('All'),
                     'isAnyWeb' => true,
                     'url' => get_permalink($post->ID),
-                    'contents' => array('en' => stripslashes_deep($notif_content)),
+                    'contents' => array('en' => stripslashes_deep(wp_specialchars_decode($notif_content))),
                 );
 
                 $send_to_mobile_platforms = $onesignal_wp_settings['send_to_mobile_platforms'];

--- a/onesignal.php
+++ b/onesignal.php
@@ -6,7 +6,7 @@ defined('ABSPATH') or die('This page may not be accessed directly.');
  * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description: Free web push notifications.
- * Version: 2.2.2
+ * Version: 2.2.3
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://onesignal.com
 Tags: push notification, push notifications, desktop notifications, mobile notifications, chrome push, android, android notification, android notifications, android push, desktop notification, firefox, firefox push, mobile, mobile notification, notification, notifications, notify, onesignal, push, push messages, safari, safari push, web push, chrome
 Requires at least: 3.8
 Tested up to: 5.8
-Stable tag: 2.2.2
+Stable tag: 2.2.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,7 +23,7 @@ You can configure notification delivery at preset intervals, create user segment
 OneSignal’s free plan allows targeting up to 10,000 subscribers with push notifications. Contact support@onesignal.com if you have any questions. We’d love to hear from you!
 
 = Company =
-OneSignal is trusted by over 1,300,000 developers and marketing strategists. We power push notifications for everyone from early stage startups to Fortune 500 Companies, sending over 6 billion notifications per day. It is the most popular push notification plugin on Wordpress with 100,000+ installations.
+OneSignal is trusted by over 1,400,000 developers and marketing strategists. We power push notifications for everyone from early stage startups to Fortune 500 Companies, sending over 6 billion notifications per day. It is the most popular push notification plugin on Wordpress with 100,000+ installations.
 
 = Features =
 * **Supports Chrome** (Desktop & Android), **Safari** (Mac OS X), **Microsoft Edge** (Desktop & Android), **Opera** (Desktop & Android) and **Firefox** (Desktop & Android) on both HTTP and HTTPS sites.
@@ -66,6 +66,10 @@ OneSignal is trusted by over 1,300,000 developers and marketing strategists. We 
 HTTPS Setup Video: [youtube https://www.youtube.com/watch?v=BeTZ2KgytC0]
 
 == Changelog ==
+
+= 2.2.3 =
+
+- Includes minor (non-critical) security improvements to notification customization functionality
 
 = 2.2.2 =
 


### PR DESCRIPTION
Includes non-critical minor improvements to the custom OneSignal notifications tool. It is best Wordpress practice is to apply escaping/sanitization methods to the data twice (prior to saving to a database and again when taking it out).

Changes to be included in 2.2.3 Release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/283)
<!-- Reviewable:end -->
