### PR TITLE
add post type filter to enable ability to programmatically maintain which post type editor screens will use the meta box

### DIFF
--- a/onesignal-admin.php
+++ b/onesignal-admin.php
@@ -256,6 +256,7 @@ class OneSignal_Admin
         $output = 'names';
         $operator = 'and';
         $post_types = get_post_types($args, $output, $operator);
+        $post_types = apply_filters( 'onesignal_post_types_display_meta_box', $post_types );
         foreach ($post_types  as $post_type) {
             add_meta_box(
         'onesignal_notif_on_post',


### PR DESCRIPTION
Applies to #286.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/287)
<!-- Reviewable:end -->
