### PR TITLE
Use the is-AMP method in onesignal_header

### DIFF
--- a/onesignal-public.php
+++ b/onesignal-public.php
@@ -53,7 +53,7 @@ class OneSignal_Public
     public static function onesignal_header()
     {
 
-        if ( function_exists( 'amp_is_request' ) && amp_is_request() ) {
+        if ( self::onesignal_is_amp() ) {
 
             if ( function_exists( 'amp_is_legacy' ) && amp_is_legacy() ) {
                 add_action( 'amp_post_template_body_open', array( __CLASS__, 'insert_amp_web_push' ) );


### PR DESCRIPTION
To allow filtering. [`amp_is_request` is the same as `is_amp_endpoint` (used in `onesignal_is_amp`)](https://github.com/ampproject/amp-wp/blob/develop/includes/amp-helper-functions.php#L832-L834).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/298)
<!-- Reviewable:end -->
