### PR TITLE
Fix jQuery bug happening due to notice.js running on page editor also

### DIFF
--- a/notice.js
+++ b/notice.js
@@ -44,7 +44,12 @@ function notice() {
     state.status = status;
 
     // is checked
-    const send_os_notif = jQuery("#send_onesignal_notification")[0].checked;
+    let send_os_notif;
+    const htmlElement = jQuery("#send_onesignal_notification")[0];
+    
+    if (!!htmlElement) {
+       send_os_notif = htmlElement.checked;
+    }
 
     // if last modified differs from first modified times, post_modified = true
     const post_modified = modified !== state.first_modified;


### PR DESCRIPTION
# Description
On WP sites using Gutenberg editor, `notice.js` also runs on Page edits, not just Post edits. This causes the script to not find the element it is looking for with jQuery and leads to a crash.

This PR checks the element was found prior to trying to access its attributes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/302)
<!-- Reviewable:end -->
