### PR TITLE
Add nofollow robots HTML tag to prevent search engine crawling at SW scope

### DIFF
--- a/sdk_files/push/onesignal/index.html
+++ b/sdk_files/push/onesignal/index.html
@@ -1,0 +1,2 @@
+<!-- Prevent search bots from indexing this folder if directory listing is enabled on the server -->
+<html><head><meta name="robots" content="noindex, nofollow"></head><body></body></html>


### PR DESCRIPTION
Motivation: Google Search Console is indexing the service worker scope

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-wordpress-plugin/304)
<!-- Reviewable:end -->
