### PR TITLE
2.4.1 Release Commit

### DIFF
--- a/onesignal.php
+++ b/onesignal.php
@@ -6,7 +6,7 @@ defined('ABSPATH') or die('This page may not be accessed directly.');
  * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description: Free web push notifications.
- * Version: 2.4.0
+ * Version: 2.4.1
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://onesignal.com
 Tags: push notification, push notifications, desktop notifications, mobile notifications, chrome push, android, android notification, android notifications, android push, desktop notification, firefox, firefox push, mobile, mobile notification, notification, notifications, notify, onesignal, push, push messages, safari, safari push, web push, chrome
 Requires at least: 3.8
 Tested up to: 6.2
-Stable tag: 2.4.0
+Stable tag: 2.4.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,11 @@ OneSignal is trusted by over 1.8M+ developers and marketing strategists. We powe
 HTTPS Setup Video: [youtube https://www.youtube.com/watch?v=BeTZ2KgytC0]
 
 == Changelog ==
+
+= 2.4.1 =
+- Update "Tested up to" Wordpress version 6.2
+- Fixed "OneSignal Push:There were no recipients..." error when there are subscribers
+- Fixed "OneSignal Slide Prompt" disabled setting not being respected
 
 = 2.4.0 =
 - Remove recipient count after post publishing.


### PR DESCRIPTION
## Release notes
- Update "Tested up to" Wordpress version 6.2
- Fixed "OneSignal Push:There were no recipients..." error when there are subscribers
- Fixed "OneSignal Slide Prompt" disabled setting not being respected

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/318)
<!-- Reviewable:end -->
