### PR TITLE
Remove HTTP video link

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -59,9 +59,6 @@ OneSignal is trusted by over 1.8M+ developers and marketing strategists. We powe
 
 == Frequently Asked Questions ==
 
-= HTTP Site Setup Video =
-[youtube https://www.youtube.com/watch?v=j8qO9gDr9Wg]
-
 = HTTPS Site Setup Video =
 HTTPS Setup Video: [youtube https://www.youtube.com/watch?v=BeTZ2KgytC0]
 


### PR DESCRIPTION
OneSignal's dashboard doesn't allow creating new HTTP (non-HTTPS) sites any more.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/322)
<!-- Reviewable:end -->
