### PR TITLE
2.4.5 - Deprecation Notice

### DIFF
--- a/configuration-export.php
+++ b/configuration-export.php
@@ -1,0 +1,58 @@
+<?php
+
+function onesignal_handle_export()
+{
+    if (isset($_POST['plugin_action']) && $_POST['plugin_action'] === 'export_settings') {
+
+        if (!check_admin_referer('onesignal_export_nonce')) {
+            wp_die(__('Security check failed', 'onesignal-push'));
+        }
+
+        $settings = get_option('OneSignalWPSetting');
+
+        // name and define settings groups
+        $groups = [
+            'OneSignal App ID' => '/^app_id/',
+            'General Options' => '/^(chrome_auto_|persist_|default_|utm_additional_)/',
+            'Slide Prompt Customizations' => '/^(prompt_customize_|prompt_action_|prompt_accept_|prompt_cancel_|prompt_auto_register)/',
+            'Subscription Bell Customizations' => '/^notifyButton_/',
+            'Welcome Notification Customizations'  => '/^(send_welcome_|welcome_)/',
+            'Plugin Settings & HTTP Setup - NO LONGER REQUIRED / DEPRECATED' => '/^(allowed_custom_|customize_http_|custom_manifest_|gcm_|is_site_|notification_on_|notification_title|onesignal_sw_|origin|prompt_auto_accept_title|prompt_example_|prompt_site_name|send_to_mobile_|showNotification|show_gcm_|how_notification_send_|subdomain|use_)/'
+        ];
+
+        // sort settings into the defined groups
+        foreach ($settings as $key => $value) {
+            foreach ($groups as $group_name => $pattern) {
+                if (preg_match($pattern, $key)) {
+                    $grouped_settings[$group_name][$key] = is_array($value) ? json_encode($value) : $value;
+                    break;
+                }
+            }
+        }
+
+        // create txt file with main title, group names, and settings.
+        $txt_data = "OneSignal Push Configuration Export\n\n\n";
+
+        foreach ($groups as $group_name => $pattern) {
+            if (isset($grouped_settings[$group_name])) {
+                $txt_data .= "=== $group_name ===\n";
+
+                foreach ($grouped_settings[$group_name] as $key => $value) {
+                    $txt_data .= "$key: $value\n";
+                }
+
+                $txt_data .= "\n\n";
+            }
+        }
+
+        header('Content-Type: text/plain');
+        header('Content-Disposition: attachment; filename="onesignal-configuration-export.txt"');
+        header('Content-Length: ' . strlen($txt_data));
+        header('Pragma: public');
+
+        echo $txt_data;
+        exit;
+    }
+}
+
+add_action('admin_init', 'onesignal_handle_export');

--- a/deprecation-notice.js
+++ b/deprecation-notice.js
@@ -1,0 +1,9 @@
+jQuery(document).ready(function ($) {
+    $('#onesignal-update-notice').on('click', '.notice-dismiss', function () {
+        $.post(onesignalData.ajax_url, {
+            action: 'dismiss_onesignal_deprecation_notice',  // This action should match the PHP function's AJAX hook
+            nonce: onesignalData.nonce,
+        });
+    });
+});
+

--- a/deprecation-notice.php
+++ b/deprecation-notice.php
@@ -1,0 +1,55 @@
+<?php
+// Add an admin notice for outdated plugin version
+add_action('admin_notices', 'notify_plugin_update');
+function notify_plugin_update() {
+    $dismissed_timestamp = get_option('onesignal_deprecation_notice_dismissed_time');
+    $time_passed = !$dismissed_timestamp || (time() - $dismissed_timestamp) > (7 * DAY_IN_SECONDS);
+    $cutoff_date = strtotime('2025-12-31 23:59:59'); // Set cutoff date and time
+
+    // Show the notice only if it's before the cutoff date and the notice has not been recently dismissed
+    if (time() <= $cutoff_date && $time_passed) {
+        echo '
+        <div class="notice notice-warning is-dismissible" id="onesignal-update-notice">
+            <p>
+              <strong>
+                OneSignal Push Important Update:</strong>
+                Before updating to Version 3 of the OneSignal WordPress plugin you must migrate your configuration to dashboard.onesignal.com.
+                <a target="_blank" href="https://documentation.onesignal.com/docs/wordpress-plugin-30">Learn More.</a>
+            </p>
+        </div>';
+    }
+}
+
+// Handle AJAX dismissal of the notice
+add_action('wp_ajax_dismiss_onesignal_deprecation_notice', 'dismiss_onesignal_deprecation_notice');
+function dismiss_onesignal_deprecation_notice() {
+    // Check if nonce is valid
+    if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'dismiss_notice_nonce')) {
+        // If nonce is invalid, log the error and return a JSON error response
+        error_log('Invalid nonce for AJAX request');
+        wp_send_json_error(array('message' => 'Invalid nonce'));
+        return;
+    }
+
+    // Update the option if nonce validation passes
+    update_option('onesignal_deprecation_notice_dismissed_time', time());
+    wp_send_json_success(array('message' => 'Dismissal timestamp set successfully'));
+}
+
+add_action('admin_enqueue_scripts', 'enqueue_notify_plugin_scripts');
+function enqueue_notify_plugin_scripts() {
+    wp_enqueue_script('onesignal-admin', plugin_dir_url(__FILE__) . 'deprecation-notice.js', array('jquery'), '1.0', true);
+    wp_localize_script('onesignal-admin', 'onesignalData', array(
+        'ajax_url' => admin_url('admin-ajax.php'),
+        'nonce' => wp_create_nonce('dismiss_notice_nonce')
+    ));
+}
+
+// Disable Auto-Updates
+add_filter('auto_update_plugin', function ($update, $item) {
+  // Check for the OneSignal plugin slug
+  if ($item->slug === 'onesignal-free-web-push-notifications/onesignal.php') {
+      return false; // Disable auto-update for this plugin
+  }
+  return $update;
+}, 10, 2);

--- a/deprecation-notice.php
+++ b/deprecation-notice.php
@@ -13,7 +13,7 @@ function notify_plugin_update() {
             <p>
               <strong>
                 OneSignal Push Important Update:</strong>
-                Before updating to Version 3 of the OneSignal WordPress plugin you must migrate your configuration to dashboard.onesignal.com.
+                We are soon releasing Version 3 of the OneSignal WordPress Plugin. Before updating, you must migrate your configuration to dashboard.onesignal.com.
                 <a target="_blank" href="https://documentation.onesignal.com/docs/wordpress-plugin-30">Learn More.</a>
             </p>
         </div>';

--- a/onesignal.php
+++ b/onesignal.php
@@ -25,6 +25,7 @@ require_once plugin_dir_path(__FILE__).'onesignal-public.php';
 require_once plugin_dir_path(__FILE__).'onesignal-settings.php';
 require_once plugin_dir_path(__FILE__).'onesignal-widget.php';
 include_once plugin_dir_path(__FILE__).'deprecation-notice.php';
+include_once plugin_dir_path(__FILE__).'configuration-export.php';
 
 if (file_exists(plugin_dir_path(__FILE__).'onesignal-extra.php')) {
     require_once plugin_dir_path(__FILE__).'onesignal-extra.php';

--- a/onesignal.php
+++ b/onesignal.php
@@ -6,7 +6,7 @@ defined('ABSPATH') or die('This page may not be accessed directly.');
  * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description: Free web push notifications.
- * Version: 2.4.4
+ * Version: 2.4.5
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT

--- a/onesignal.php
+++ b/onesignal.php
@@ -24,6 +24,7 @@ require_once plugin_dir_path(__FILE__).'onesignal-admin.php';
 require_once plugin_dir_path(__FILE__).'onesignal-public.php';
 require_once plugin_dir_path(__FILE__).'onesignal-settings.php';
 require_once plugin_dir_path(__FILE__).'onesignal-widget.php';
+include_once plugin_dir_path(__FILE__).'deprecation-notice.php';
 
 if (file_exists(plugin_dir_path(__FILE__).'onesignal-extra.php')) {
     require_once plugin_dir_path(__FILE__).'onesignal-extra.php';

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: OneSignal
 Donate link: https://onesignal.com
 Tags: push notification, push notifications, desktop notifications, mobile notifications, chrome push, android, android notification, android notifications, android push, desktop notification, firefox, firefox push, mobile, mobile notification, notification, notifications, notify, onesignal, push, push messages, safari, safari push, web push, chrome
 Requires at least: 3.8
-Tested up to: 6.5
-Stable tag: 2.4.4
+Tested up to: 6.7
+Stable tag: 2.4.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -63,6 +63,11 @@ OneSignal is trusted by over 1.8M+ developers and marketing strategists. We powe
 [youtube https://www.youtube.com/watch?v=q1mH2kCK7LQ]
 
 == Changelog ==
+
+= 2.4.5 =
+- Add v2 plugin deprecation warning
+- Add export current configuration
+- Update "Tested up to" Wordpress version to 6.7
 
 = 2.4.4 =
 - Update "Tested up to" Wordpress version to 6.5

--- a/views/config.php
+++ b/views/config.php
@@ -23,6 +23,7 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
       <span style="padding:0 20px 15px; color:#E54B4D; font-weight:700;">
         ⚠️ OneSignal Push Important Update:<br><br>
         <p style="font-size:1.15rem;">We are soon releasing Version 3 of the OneSignal WordPress Plugin. Before updating, you must migrate your configuration to dashboard.onesignal.com.</p>
+        <p style="font-size:1.15rem;">Note: after migrating, the settings on this page will be overrided by the new dashboard.onesignal.com settings.</p>
         <form method="post" action="">
           <?php wp_nonce_field('onesignal_export_nonce'); ?>
           <input type="hidden" name="plugin_action" value="export_settings">

--- a/views/config.php
+++ b/views/config.php
@@ -3,8 +3,8 @@
 defined('ABSPATH') or die('This page may not be accessed directly.');
 
 if (!OneSignalUtils::can_modify_plugin_settings()) {
-    // Exit if the current user does not have permission
-    die('Insufficient permissions to access config page.');
+  // Exit if the current user does not have permission
+  die('Insufficient permissions to access config page.');
 }
 
 // The user is just viewing the config page; this page cannot be accessed directly
@@ -20,239 +20,22 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
 <div class="outer site onesignal container">
   <div class="ui site onesignal container" id="content-container">
     <div class="ui menu">
-      <span style="padding-bottom:15px; padding-left:20px; color:#E54B4D; font-weight:700;">
+      <span style="padding:0 20px 15px; color:#E54B4D; font-weight:700;">
         ⚠️ OneSignal Push Important Update:<br><br>
-        Before updating to Version 3 of the OneSignal WordPress plugin you must migrate your configuration to dashboard.onesignal.com.
-        <a href="https://documentation.onesignal.com/docs/wordpress-plugin-30" target="_blank">Learn more.</a>
+        <p style="font-size:1.15rem;">We are soon releasing Version 3 of the OneSignal WordPress Plugin. Before updating, you must migrate your configuration to dashboard.onesignal.com.</p>
+        <form method="post" action="">
+          <?php wp_nonce_field('onesignal_export_nonce'); ?>
+          <input type="hidden" name="plugin_action" value="export_settings">
+          <button type="button" class="ui medium teal button" onclick="window.open('https://documentation.onesignal.com/docs/wordpress-plugin-30','_blank');">Learn More</button>
+          <button type="submit" class="ui medium button">Export Current Configuration</button>
+        </form>
       </span>
     </div>
-    <div class="ui menu">
-      <span style="padding-bottom:15px; padding-left:20px; color:#E54B4D; font-weight:700;">
-	⭐ Appreciate OneSignal?
-	<a style="margin-left:15px;" href="https://wordpress.org/support/plugin/onesignal-free-web-push-notifications/reviews/#new-post" target="_blank">Leave us a review →	</a>
-      </span>
-    </div>
-    <div class="ui pointing stackable menu">
-      <a class="item" data-tab="setup">Setup</a>
-      <a class="active item" data-tab="configuration">Configuration</a>
-    </div>
-    <div class="ui tab borderless shadowless segment" data-tab="setup" style="padding-top: 0; padding-bottom: 0;">
-      <div class="ui special padded segment" style="padding-top: 0 !important;">
-      <div class="ui top secondary pointing menu">
-      <div class="ui grid" style="margin: 0 !important; padding: 0 !important;">
-        <a class="item" data-tab="setup/0">Overview</a>
-        <a class="item" data-tab="setup/1">Prompts</a>
-        <a class="item" data-tab="setup/2">Safari Push</a>
-        <a class="item" data-tab="setup/3">Results</a>
-        </div>
-      </div>
-      <div class="ui tab borderless shadowless segment" data-tab="setup/0">
-        <p>Follow these steps to add Web Push to your Wordpress blog:</p>
-        <dl>
-          <div class="ui segment">
-            <dt>1</dt>
-            <dd>
-              <p>Create a <a href="https://onesignal.com" target="_blank">OneSignal</a> account or log in to your existing account.</p>
-            </dd>
-          </div>
-          <div class="ui segment">
-            <dt>2</dt>
-            <dd>
-              <p>
-                Create a Web Push app in OneSignal, following the instructions in our
-                <a href="https://documentation.onesignal.com/docs/web-push-quickstart" target="_new">Web Push Quickstart guide</a>.
-              </p>
-            </dd>
-          </div>
-          <div class="ui segment">
-            <dt>3</dt>
-            <dd>
-              <p>
-                Set up your Web Push app following the instructions in OneSignal's <strong>Web Push Editor</strong>.
-              </p>
-            </dd>
-          </div>
-        </dl>
-
-        <div class="ui center aligned piled segment">
-          <i class="big grey pin pinned icon"></i>
-          <h3>Troubleshooting</h3>
-          <p>
-            If you run into issues or need extra guidance, you can follow along each step of our
-            <a href="https://documentation.onesignal.com/docs/wordpress" target="_new">Wordpress Setup Guide</a>.
-          </p>
-          <p>
-            If you're ever stuck or have questions, <a href="mailto:support+wp@onesignal.com">email us</a>!
-          </p>
-          <p>
-            If you run into issues getting your plugin to work, you can also browse our
-            <a href="https://documentation.onesignal.com/docs/troubleshooting-web-push" target="_blank">Troubleshooting Website Push</a> documentation.
-          </p>
-        </div>
-      </div>
-
-      <div class="ui tab borderless shadowless segment" style="z-index: 1;" data-tab="setup/1">
-        <p>If you've finished the guide up to here, push notifications already work on your site. <strong>But your users still need a way to <em>subscribe</em> to your site's notifications</strong>. There are a couple ways:
-          <h4>HTTP Sites:</h4>
-          <div class="relative ui two column middle aligned very relaxed stackable grid" style="margin-bottom: 0 !important; padding-bottom: 0 !important;">
-            <div class="center aligned column">
-              <img class="img-responsive" src="<?php echo esc_url(ONESIGNAL_PLUGIN_URL."views/images/settings/http-prompt.png") ?>" width="100%">
-            </div>
-            <div class="center aligned column">
-              <img class="img-responsive" src="<?php echo esc_url(ONESIGNAL_PLUGIN_URL."views/images/bell.jpg") ?>" width="60%">
-            </div>
-          </div>
-          <div class="relative ui two column middle aligned very relaxed stackable grid" style="margin-top: 0 !important; padding-top: 0 !important;">
-            <div class="center aligned column">
-              <h3>Slide Prompt</h3>
-            </div>
-            <div class="center aligned column">
-              <h3>Subscription Bell</h3>
-            </div>
-          </div>
-          <h4>HTTPS Sites:</h4>
-          <div class="relative ui two column middle aligned very relaxed stackable grid" style="margin-bottom: 0 !important; padding-bottom: 0 !important;">
-            <div class="center aligned column">
-              <img class="img-responsive" src="<?php echo esc_url(ONESIGNAL_PLUGIN_URL."views/images/settings/https-prompt.png") ?>" width="100%">
-            </div>
-            <div class="center aligned column">
-              <img class="img-responsive" src="<?php echo esc_url(ONESIGNAL_PLUGIN_URL."views/images/bell.jpg") ?>" width="60%">
-            </div>
-          </div>
-          <div class="relative ui two column middle aligned very relaxed stackable grid" style="margin-top: 0 !important; padding-top: 0 !important;">
-            <div class="center aligned column">
-              <h3>Browser Permission Request <span class="ui green horizontal label">HTTPS Only</span></h3>
-            </div>
-            <div class="center aligned column">
-              <h3>Subscription Bell</h3>
-            </div>
-          </div>
-          <ol>
-            <li><strong>Subscription Bell:</strong> Enable it in <em>Configuration</em> -> <em>Prompt Settings & Subscription Bell</em> -> <em>Enable the Subscription Bell</em></li>
-            <ol>
-              <li>The Subscription Bell is an interactive site widget.</li>
-              <li>Users see the Subscription Bell on the bottom right corner of your site. They can click the Subscription Bell to subscribe.</li>
-              <li>The Subscription Bell is custom developed by us and does all the work for you! It detects when users are unsubscribed, already subscribed, or have blocked your site and show instructions to unblock. It allows users to easily temporarily subscribe from and resubscribe to notifications.</li>
-            </ol>
-            <li><strong>HTTP/HTTPS Prompt:</strong> Enable it in <em>Configuration</em> -> <em>Prompt Settings & Subscription Bell</em> -> <em>Automatically prompt new site visitors to subscribe to push notifications</em></li>
-            <ol>
-              <li><a href="https://documentation.onesignal.com/docs/permission-requests" target="_blank">Read more about it at our documentation.</a></li>
-            </ol>
-          </ol>
-          <p>If you're a technical user and would like to implement your own subscription process, this is entirely possible. Please see this guide on <a href="https://documentation.onesignal.com/docs/customize-permission-messages#section-custom-link-permission-message" target="_blank">how to subscribe user with a link</a> using HTML and JavaScript. Our <a href="https://documentation.onesignal.com/docs/web-push-sdk" target="_blank">web SDK JavaScript API</a> is also available and can be called anywhere on the page.</p>
-        </p>
-
-        <dl>
-          <div class="ui segment">
-              <p>You're done setting up your site for Chrome & Firefox push!</p>
-              <p>Your site works completely with Chrome & Firefox push now. You can learn how to add <a href="javascript:void(0);" onclick="activateSetupTab('setup/4')">Safari</a> web push.</p>
-          </div>
-        </dl>
-      </div>
-      <div class="ui tab borderless shadowless segment" style="z-index: 1;" data-tab="setup/2">
-        <dl>
-          <div class="ui center aligned piled segment">
-            <i class="big grey pin pinned icon"></i>
-            <h3>Safari on Windows Not Supported</h3>
-            <p>Safari on Windows does not support web push notifications. Please use Safari on Mac OS X. <a href="https://onesignal.com/blog/when-will-web-push-be-supported-in-ios/" target="_blank">Apple also does not support web push notifications on iOS yet.</a></p>
-          </div>
-          <div class="ui segment">
-            <dt>1</dt>
-            <dd>
-              <p>Log in to your OneSignal account, and navigate to the <em>App Settings</em> page of the app you configured in this guide.</p>
-              <p>You should be on this page:</p>
-              <img class="img-responsive" src="<?php echo esc_url(ONESIGNAL_PLUGIN_URL."views/images/settings/safari-1.jpg") ?>">
-              <p>Click <strong>Configure</strong> on the platform <em>Apple Safari</em>.</p>
-            </dd>
-          </div>
-          <div class="ui segment">
-            <dt>2</dt>
-            <dd>
-              <p>In this step, we'll focus on filling out the <em>Site Name</em> and <em>Site URL</em> fields.</p>
-              <img class="img-responsive" src="<?php echo esc_url(ONESIGNAL_PLUGIN_URL."views/images/settings/safari-2.jpg") ?>">
-              <p>For the <strong>Site Name</strong>, enter a name you'd like your users to see.</p>
-              <p>In the following sample image, <em>OneSignal</em> is the site name:</p>
-              <img class="img-responsive" src="<?php echo esc_url(ONESIGNAL_PLUGIN_URL."views/images/settings/safari-prompt.jpg") ?>" width="450">
-              <p>For the <strong>Site URL</strong>, enter the URL to your site's domain. The purpose of this field is to prevent other sites from hijacking your keys to impersonate you and send push notifications on your behalf. Please note:</p>
-              <ul>
-                <li>
-                  <p>Don't include trailing slashes</p>
-                  <p>Instead of using <code>http://domain.com/</code>, use <code>http://domain.com</code> instead.</p>
-                  <p></p>
-                </li>
-                <li>
-                  <p>Don't include subfolders</p>
-                  <p>Even if your WordPress blog is hosted on <code>http://domain.com/resource/blog</code>, use <code>http://domain.com</code></p>
-                  <p></p>
-                </li>
-                <li>
-                  <p>Include the correct protocol</p>
-                  <p>If your site uses HTTPS, use <code>https://domain.com</code>. If your site uses a mix of HTTPS/HTTP or only HTTP, use <code>http://domain.com</code>.</a>.</p>
-                  <p></p>
-                </li>
-              </ul>
-            </dd>
-          </div>
-          <div class="ui segment">
-            <dt>3</dt>
-            <dd>
-              <p>In this step, we'll focus on uploading your Safari notification icons.</p>
-              <img class="img-responsive" src="<?php echo esc_url(ONESIGNAL_PLUGIN_URL."views/images/settings/safari-3.jpg") ?>">
-              <p>Please have your icon in the following sizes:</p>
-              <ul>
-                <li>16 &times; 16</li>
-                <li>32 &times; 32</li>
-                <li>64 &times; 64</li>
-                <li>128 &times; 128</li>
-                <li>256 &times; 256</li>
-              </ul>
-              <p>The different sizes are used in different places (e.g. the <code>64 &times; 64</code> icon is used in the allow notification prompt). If you don't have these different sizes, you may simply upload one <code>256 &times; 256</code> icon into each entry, and we will resize them for you to the appropriate size.</p>
-            </dd>
-          </div>
-          <div class="ui segment">
-            <dt>4</dt>
-            <dd>
-              <p>Click <strong>Save</strong> to commit your Safari push settings <strong>and then exit the dialog</strong>.</p>
-              <p>If you get errors please follow the instructions to fix them. If you're still experiencing problems, email us for support.</p>
-            </dd>
-          </div>
-          <div class="ui segment">
-            <dt>5</dt>
-            <dd>
-              <p><strong>Refresh</strong> the page, and then copy the <strong>Safari Web ID</strong> you see to the <em>Configuration</em> tab.</p>
-              <img class="img-responsive" src="<?php echo esc_url(ONESIGNAL_PLUGIN_URL."views/images/settings/safari-4.jpg") ?>">
-              <p>That's it for setting up Safari push!</p>
-            </dd>
-          </div>
-          <div class="ui center aligned piled segment">
-            <i class="big grey pin pinned icon"></i>
-            <h3>Safari Web ID (optional)</h3>
-            <p>Copy the <strong>Safari Web ID</strong> to the <em>Configuration</em> tab.</p>
-          </div>
-        </dl>
-      </div>
-      <div class="ui tab borderless shadowless segment" style="z-index: 1;" data-tab="setup/3">
-        <p>This section shows push notifications working for <em>Chrome</em>, <em>Safari</em>, and <em>Firefox</em> in <em>HTTP</em> and <em>HTTPS</em> mode.</p>
-        <img class="img-responsive" src="<?php echo esc_url(ONESIGNAL_PLUGIN_URL."views/images/settings/web-push.jpg") ?>">
-        <p></p>
-        <dl>
-          <div class="ui horizontal divider">Subscription Bell</div>
-          <img class="img-responsive" src="<?php echo esc_url(ONESIGNAL_PLUGIN_URL."views/images/settings/notify-button.jpg") ?>">
-          <div class="ui horizontal divider">Chrome (HTTP)</div>
-          <img class="img-responsive" src="<?php echo esc_url(ONESIGNAL_PLUGIN_URL."views/images/settings/chrome-http.jpg") ?>">
-          <div class="ui horizontal divider">Chrome (HTTPS)</div>
-          <img class="img-responsive" src="<?php echo esc_url(ONESIGNAL_PLUGIN_URL."views/images/settings/chrome-https.jpg") ?>">
-          <div class="ui horizontal divider">Safari (HTTP & HTTPS)</div>
-          <img class="img-responsive" src="<?php echo esc_url(ONESIGNAL_PLUGIN_URL."views/images/settings/safari-https.jpg") ?>">
-          <div class="ui horizontal divider">Firefox (HTTP)</div>
-          <img class="img-responsive" src="<?php echo esc_url(ONESIGNAL_PLUGIN_URL."views/images/settings/firefox-http.jpg") ?>">
-          <div class="ui horizontal divider">Firefox (HTTPS)</div>
-          <img class="img-responsive" src="<?php echo esc_url(ONESIGNAL_PLUGIN_URL."views/images/settings/firefox-https.jpg") ?>">
-        </dl>
-      </div>
-    </div>
-    </div>
-    <div class="ui borderless shadowless active tab segment" style="z-index: 1; padding-top: 0; padding-bottom: 0;" data-tab="configuration">
+  </div>
+  <div class="ui pointing stackable menu">
+    <a class="active item" data-tab="configuration">Configuration</a>
+  </div>
+  <div class="ui borderless shadowless active tab segment" style="z-index: 1; padding-top: 0; padding-bottom: 0;" data-tab="configuration">
     <div class="ui special padded raised stack segment">
       <form class="ui form" role="configuration" action="#" method="POST">
         <?php
@@ -784,6 +567,6 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
         </div>
       </form>
     </div>
-    </div>
   </div>
+</div>
 </div>

--- a/views/config.php
+++ b/views/config.php
@@ -21,6 +21,13 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
   <div class="ui site onesignal container" id="content-container">
     <div class="ui menu">
       <span style="padding-bottom:15px; padding-left:20px; color:#E54B4D; font-weight:700;">
+        ⚠️ OneSignal Push Important Update:<br><br>
+        Before updating to Version 3 of the OneSignal WordPress plugin you must migrate your configuration to dashboard.onesignal.com.
+        <a href="https://documentation.onesignal.com/docs/wordpress-plugin-30" target="_blank">Learn more.</a>
+      </span>
+    </div>
+    <div class="ui menu">
+      <span style="padding-bottom:15px; padding-left:20px; color:#E54B4D; font-weight:700;">
 	⭐ Appreciate OneSignal?
 	<a style="margin-left:15px;" href="https://wordpress.org/support/plugin/onesignal-free-web-push-notifications/reviews/#new-post" target="_blank">Leave us a review →	</a>
       </span>


### PR DESCRIPTION
# One line summary
Add a deprecation notice for OS configuration in the plugin.

# Description
This update introduces a **deprecation notice** displayed at an admin level across the plugin as well as in the plugin dashboard, informing users that OneSignal configuration will be moved to OneSignal.com. The notice links to more [detailed documentation](https://documentation.onesignal.com/docs/wordpress-plugin-30).

Additional details:
- **Dismissal Logic:** If dismissed, the notice will reappear after 7 days.
- **End Date:** Notices will stop reappearing after December 31, 2024, providing a buffer period for users. Although the plugin dashboard notice will always show on the v2 plugin dashboard.

# Screenshots:
## Admin Panel (Home)
![Screenshot 2024-11-08 at 4 19 08 PM](https://github.com/user-attachments/assets/fdfe9404-be20-45e2-ab07-de5c9859a813)
## Plugin Dashboard
![Screenshot 2024-11-15 at 4 05 59 PM](https://github.com/user-attachments/assets/024871de-ec0d-456e-9b19-bc56a2768f9c)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/332)
<!-- Reviewable:end -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208721222190810