### PR TITLE
3.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,66 @@
+ChromePhp.php
+onesignal-free-web-push-notifications.zip
+views/images/settings/ParseToOneSignal.png
+.vscode/
+
+.map
+**/*.map
+onesignal-free-push-notifications.zip
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+
+# Created by .ignore support plugin (hsz.mobi)
+
+.DS_Store
+
+onesignal-extra.php
+
+docker-instance-files/*
+# Expection to the rule as we need this files to modify plugin upload limits
+!uploads.ini

--- a/onesignal.php
+++ b/onesignal.php
@@ -6,7 +6,7 @@ defined('ABSPATH') or die('This page may not be accessed directly.');
  * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description: Free web push notifications.
- * Version: 3.0.1
+ * Version: 3.0.2
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT

--- a/onesignal.php
+++ b/onesignal.php
@@ -54,4 +54,15 @@ if ($plugin_version === ONESIGNAL_VERSION_V3) {
     // Initialize V2 admin and public components
     add_action('init', ['OneSignal_Admin', 'init']);
     add_action('init', ['OneSignal_Public', 'init']);
+    add_action('admin_notices', 'migration_notice');
+}
+
+function migration_notice() {
+    // Only show the notice on the Plugins page
+    $screen = get_current_screen();
+    if ($screen && $screen->id === 'plugins') {
+        echo '<div class="notice notice-warning is-dismissible">
+                <p><strong>OneSignal Migration Needed:</strong> All OneSignal prompt configurations are moving to OneSignal.com. See the plugin page for more info.</p>
+              </div>';
+    }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://onesignal.com
 Tags: push notification, push notifications, desktop notifications, mobile notifications, chrome push, android, android notification, android notifications, android push, desktop notification, firefox, firefox push, mobile, mobile notification, notification, notifications, notify, onesignal, push, push messages, safari, safari push, web push, chrome
 Requires at least: 3.8
 Tested up to: 6.7
-Stable tag: 3.0.1
+Stable tag: 3.0.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -63,6 +63,9 @@ OneSignal is trusted by over 1.8M+ developers and marketing strategists. We powe
 [youtube https://www.youtube.com/watch?v=q1mH2kCK7LQ]
 
 == Changelog ==
+
+= 3.0.2 =
+- Adding an admin notice and updated styles to encourage settings migration.
 
 = 3.0.1 =
 WARNING: this update contains changes that may break specific setups, as detailed below:

--- a/v2/views/config.php
+++ b/v2/views/config.php
@@ -65,11 +65,15 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
           <div id="migration-confirmation-modal" class="ui modal">
               <div class="header">Confirm Migration</div>
               <div class="content">
-                  <p>Are you sure you want to mark the plugin as migrated? This action is irreversible.</p>
+                <span class="onesignal-error-notice">
+                  This action is irreversible.
+                </span><br/><br/>
+                  <p>By confirming the migration, you confirm that you have configured your prompt settings on the OneSignal.com dashboard.</p>
+                  <p>Are you sure you want to mark the plugin as migrated?</p>
               </div>
               <div class="actions">
                   <button class="ui cancel button">Cancel</button>
-                  <button class="ui approve button" id="confirm-migration-submit">Confirm</button>
+                  <button class="ui approve button" id="confirm-migration-submit" style="background-color:#E54B4D">Confirm</button>
               </div>
           </div>
 

--- a/v2/views/css/site.css
+++ b/v2/views/css/site.css
@@ -846,7 +846,7 @@ header[class=onesignal] #logo-onesignal {
   background-color: #3A3DB2;
   color: white;
   border: none;
-  padding: 0.5em 1em;
+  padding: 1em 1em;
   font-size: 1.1rem;
   font-family: "Lato";
   font-weight: 500;


### PR DESCRIPTION
# One line summary
Add an admin notice and updated styles to encourage settings migration.

# Description
This update introduces an **admin notice** to prompt users to migrate their settings after upgrading the plugin. The notice is designed to be clear and prominent, ensuring that users are aware of the migration requirement.

**V2 styles** have been adjusted to emphasize the migration steps more effectively. These changes aim to reduce the likelihood of users skipping or misunderstanding critical instructions.

A missing `.gitignore` file has also been re-added.

## Screenshots
![Screenshot 2024-12-20 at 3 46 57 PM](https://github.com/user-attachments/assets/4a37479f-ff38-405c-84a4-ff4e72008a47)
![Screenshot 2024-12-20 at 3 45 18 PM](https://github.com/user-attachments/assets/fe319496-38d9-402e-8882-e37f5d2a0f19)


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/336)
<!-- Reviewable:end -->
