### PR TITLE
3.0.5 Release

### DIFF
--- a/onesignal.php
+++ b/onesignal.php
@@ -6,7 +6,7 @@ defined('ABSPATH') or die('This page may not be accessed directly.');
  * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description: Free web push notifications.
- * Version: 3.0.4
+ * Version: 3.0.5
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -79,7 +79,7 @@ WARNING: this update contains changes that may break specific setups, as detaile
 
 If you have made any code modifications to your Wordpress installation to directly interact with the OneSignal SDK, this version will break your implementation. Please revert your code modifications prior to upgrading and use our improved dashboard functionality to configure your OneSignal integration instead.
 
-Learn more: https://documentation.onesignal.com/docs/wordpress-plugin-30
+Learn more: https://documentation.onesignal.com/docs/wordpress
 
 - Support migration to new configuration flow.
 - Simpler configuration interface.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://onesignal.com
 Tags: push notification, push notifications, desktop notifications, mobile notifications, chrome push, android, android notification, android notifications, android push, desktop notification, firefox, firefox push, mobile, mobile notification, notification, notifications, notify, onesignal, push, push messages, safari, safari push, web push, chrome
 Requires at least: 3.8
 Tested up to: 6.7
-Stable tag: 3.0.4
+Stable tag: 3.0.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -63,6 +63,11 @@ OneSignal is trusted by over 1.8M+ developers and marketing strategists. We powe
 [youtube https://www.youtube.com/watch?v=q1mH2kCK7LQ]
 
 == Changelog ==
+
+= 3.0.5 =
+- Change push title and content to match 2.X version
+- Bugfix: handle missing UTM parameters
+- Update documentation links
 
 = 3.0.4 =
 - Added features: auto-send on publish, UTM tags

--- a/v2/views/config.php
+++ b/v2/views/config.php
@@ -41,7 +41,7 @@ $onesignal_wp_settings = OneSignal::get_onesignal_settings();
       <span style="padding:0 20px 15px; color:#3A3DB2; font-weight:700;">
           Migrate Settings to OneSignal.com<br><br>
           <p style="font-size:1.15rem;font-weight:500">All OneSignal prompt configurations on this page are moving to OneSignal.com.</p>
-          <button type="button" class="ui medium teal button" onclick="window.open('https://documentation.onesignal.com/docs/wordpress-plugin-30','_blank');">Learn More</button>
+          <button type="button" class="ui medium teal button" onclick="window.open('https://documentation.onesignal.com/docs/wordpress','_blank');">Learn More</button>
           <form method="post" action="" style="margin-bottom: 20px; margin-top: 20px;">
             <p style="font-size:1.15rem;">Save your current settings to a txt file</p>
             <?php wp_nonce_field('onesignal_export_nonce'); ?>

--- a/v3/README.md
+++ b/v3/README.md
@@ -1,6 +1,6 @@
 OneSignal WordPress Plugin - v3.0.0
 ====================================
-[OneSignal WordPress Plugin 3.0 – Documentation](https://documentation.onesignal.com/docs/wordpress-plugin-30)
+[OneSignal WordPress Plugin 3.0 – Documentation](https://documentation.onesignal.com/docs/wordpress)
 
 ## Overview
 

--- a/v3/onesignal-admin/onesignal-admin.css
+++ b/v3/onesignal-admin/onesignal-admin.css
@@ -143,7 +143,9 @@
   border-radius: 0.25rem;
   border: 1px solid rgb(185, 194, 202);
   padding: 1rem 2rem;
-  background-color: #fff;
+  background-color: #eee;
+  margin-bottom: 20px;
+  margin-top: 20px;
 }
 
 .os-content input[type="submit"] {

--- a/v3/onesignal-admin/onesignal-admin.js
+++ b/v3/onesignal-admin/onesignal-admin.js
@@ -1,13 +1,20 @@
 window.addEventListener("DOMContentLoaded", () => {
-  const helpIcon = document.querySelector(".help");
-  const infoDiv = document.querySelector(".information");
+  const sendToMobileHelpIcon = document.querySelector(".mobile-app .help");
+  const sendToMobileInfoDiv = document.querySelector(".mobile-app .information");
+  const utmParamsHelpIcon = document.querySelector(".utm-params .help");
+  const utmParamsInfoDiv = document.querySelector(".utm-params .information");
 
-  if (helpIcon && infoDiv) {
-    helpIcon.addEventListener("click", () => {
-      infoDiv.style.display =
-        infoDiv.style.display === "none" ? "inherit" : "none";
-    });
-  }
+  const setupToggleAction = (helpIcon, infoDiv) => {
+    if (helpIcon && infoDiv) {
+      helpIcon.addEventListener("click", () => {
+        infoDiv.style.display =
+          infoDiv.style.display === "none" ? "inherit" : "none";
+      });
+    }
+  };
+
+  setupToggleAction(sendToMobileHelpIcon, sendToMobileInfoDiv);
+  setupToggleAction(utmParamsHelpIcon, utmParamsInfoDiv);
 });
 
 window.addEventListener("DOMContentLoaded", () => {

--- a/v3/onesignal-admin/onesignal-admin.php
+++ b/v3/onesignal-admin/onesignal-admin.php
@@ -62,7 +62,7 @@ function onesignal_admin_page()
     ?>
     <div style="margin-bottom: 20px;">
       <span style="margin-bottom:35px;color:#E54B4D; font-weight:700;">
-        <a href="https://documentation.onesignal.com/docs/wordpress-plugin-30" target="_blank">Getting Started →	</a>
+        <a href="https://documentation.onesignal.com/docs/wordpress" target="_blank">Getting Started →	</a>
       </span>
     </div>
     <?php

--- a/v3/onesignal-admin/onesignal-admin.php
+++ b/v3/onesignal-admin/onesignal-admin.php
@@ -131,14 +131,24 @@ function onesignal_admin_page()
             $utmParams = esc_attr($oneSignalSettings['utm_additional_url_params']);
         }
         ?>
-        <div class="field">
-            <label>Additional Notification URL Parameters<i class="tiny circular help icon link" role="popup" data-html="Adds the specified string as extra URL parameters to your notification URL so that they can be tracked as an event by your analytics system. <em>Please escape your parameter values</em>; your input will be added as-is to the end of your notification URL. Example:</p>If you want:<em><li><code>utm_medium</code> to be <code>ppc</code></li><li><code>utm_source</code> to be <code>adwords</code></li><li><code>utm_campaign</code> to be <code>snow boots</code></li><li><code>utm_content</code> to be <code>durable snow boots</code></li></em><p><p>Then use the following string:</p><p><code style='word-break: break-all;'>utm_medium=ppc&utm_source=adwords&utm_campaign=snow%20boots&utm_content=durable%20%snow%boots</code></p>" data-variation="wide"></i></label>
+        <div class="field utm-params">
+            <label>Additional Notification URL Parameters</label>
+            <div class="help" aria-label="More information">
+              <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                <g fill="currentColor">
+                  <path d="M8 0a8 8 0 108 8 8.009 8.009 0 00-8-8zm0 12.667a1 1 0 110-2 1 1 0 010 2zm1.067-4.054a.667.667 0 00-.4.612.667.667 0 01-1.334 0 2 2 0 011.2-1.834A1.333 1.333 0 106.667 6.17a.667.667 0 01-1.334 0 2.667 2.667 0 113.734 2.444z"></path>
+                </g>
+              </svg>
+            </div>
+            <div class="information" style="display: none;">
+              <p>Adds the specified string as extra URL parameters to your notification URL so that they can be tracked as an event by your analytics system. <em>Please escape your parameter values</em>; your input will be added as-is to the end of your notification URL. Example:</p>If you want:<em><li><code>utm_medium</code> to be <code>ppc</code></li><li><code>utm_source</code> to be <code>adwords</code></li><li><code>utm_campaign</code> to be <code>snow boots</code></li><li><code>utm_content</code> to be <code>durable snow boots</code></li></em><p><p>Then use the following string:</p><p><code style='word-break: break-all;'>utm_medium=ppc&utm_source=adwords&utm_campaign=snow%20boots&utm_content=durable%20%snow%boots</code></p>
+            </div>
             <input id="utm-params" type="text" placeholder="utm_medium=ppc&utm_source=adwords&utm_campaign=snow%20boots&utm_content=durable%20%snow%boots" name="utm_additional_url_params" value="<?php echo $utmParams; ?>">
         </div>
       </div>
 
       <!-- Auto Send Checkbox -->
-      <div class="checkbox-wrapper">
+      <div class="checkbox-wrapper auto-send">
         <label for="auto-send">
           <input id="auto-send" type="checkbox" name="onesignal_auto_send"
                  <?php echo (get_option('OneSignalWPSetting')['notification_on_post'] ?? 0) == 1 ? 'checked' : ''; ?>>
@@ -148,7 +158,7 @@ function onesignal_admin_page()
       </div>
 
       <!-- Mobile App Checkbox -->
-      <div class="checkbox-wrapper">
+      <div class="checkbox-wrapper mobile-app">
         <label for="send-to-mobile">
           <input id="send-to-mobile" type="checkbox" name="onesignal_send_to_mobile"
                  <?php echo (get_option('OneSignalWPSetting')['send_to_mobile_platforms'] ?? 0) == 1 ? 'checked' : ''; ?>>

--- a/v3/onesignal-admin/onesignal-admin.php
+++ b/v3/onesignal-admin/onesignal-admin.php
@@ -122,9 +122,18 @@ function onesignal_admin_page()
 
       <h3>Advanced Settings</h3>
       <div class="ui borderless shadowless segment">
+      <?php
+        $oneSignalSettings = get_option('OneSignalWPSetting');
+        $utmParams = ''; // Default empty value
+
+        // Check if the settings are an array and if the key exists
+        if (is_array($oneSignalSettings) && isset($oneSignalSettings['utm_additional_url_params'])) {
+            $utmParams = esc_attr($oneSignalSettings['utm_additional_url_params']);
+        }
+        ?>
         <div class="field">
-          <label>Additional Notification URL Parameters<i class="tiny circular help icon link" role="popup" data-html="Adds the specified string as extra URL parameters to your notification URL so that they can be tracked as an event by your analytics system. <em>Please escape your parameter values</em>; your input will be added as-is to the end of your notification URL. Example:</p>If you want:<em><li><code>utm_medium</code> to be <code>ppc</code></li><li><code>utm_source</code> to be <code>adwords</code></li><li><code>utm_campaign</code> to be <code>snow boots</code></li><li><code>utm_content</code> to be <code>durable snow boots</code></li></em><p><p>Then use the following string:</p><p><code style='word-break: break-all;'>utm_medium=ppc&utm_source=adwords&utm_campaign=snow%20boots&utm_content=durable%20%snow%boots</code></p>" data-variation="wide"></i></label>
-          <input id="utm-params" type="text" placeholder="utm_medium=ppc&utm_source=adwords&utm_campaign=snow%20boots&utm_content=durable%20%snow%boots" name="utm_additional_url_params" value="<?php echo esc_attr(get_option('OneSignalWPSetting')['utm_additional_url_params']); ?>">
+            <label>Additional Notification URL Parameters<i class="tiny circular help icon link" role="popup" data-html="Adds the specified string as extra URL parameters to your notification URL so that they can be tracked as an event by your analytics system. <em>Please escape your parameter values</em>; your input will be added as-is to the end of your notification URL. Example:</p>If you want:<em><li><code>utm_medium</code> to be <code>ppc</code></li><li><code>utm_source</code> to be <code>adwords</code></li><li><code>utm_campaign</code> to be <code>snow boots</code></li><li><code>utm_content</code> to be <code>durable snow boots</code></li></em><p><p>Then use the following string:</p><p><code style='word-break: break-all;'>utm_medium=ppc&utm_source=adwords&utm_campaign=snow%20boots&utm_content=durable%20%snow%boots</code></p>" data-variation="wide"></i></label>
+            <input id="utm-params" type="text" placeholder="utm_medium=ppc&utm_source=adwords&utm_campaign=snow%20boots&utm_content=durable%20%snow%boots" name="utm_additional_url_params" value="<?php echo $utmParams; ?>">
         </div>
       </div>
 

--- a/v3/onesignal-helpers.php
+++ b/v3/onesignal-helpers.php
@@ -17,3 +17,20 @@ function onesignal_get_api_key_type()
 
     return (strpos($apiKey, 'os_v') === 0) ? "Rich" : "Legacy";
 }
+
+/* If >= PHP 5.4, ENT_HTML401 | ENT_QUOTES will correctly decode most entities including both double and single quotes.
+   In PHP 5.3, ENT_HTML401 does not exist, so we have to use `str_replace("&apos;","'", $value)` before feeding it to html_entity_decode(). */
+function decode_entities($string) {
+  $HTML_ENTITY_DECODE_FLAGS = ENT_QUOTES;
+  if (defined('ENT_HTML401')) {
+    $HTML_ENTITY_DECODE_FLAGS = ENT_HTML401 | $HTML_ENTITY_DECODE_FLAGS;
+  }
+  return html_entity_decode(str_replace(['&apos;', '&#x27;', '&#39;', '&quot;'], '\'', $string), $HTML_ENTITY_DECODE_FLAGS, 'UTF-8');
+}
+
+function sanitize_content_for_excerpt($content) {
+  $decoded = wp_specialchars_decode($content);
+  $stripped_slashes = stripslashes_deep($decoded);
+  $cleaned_content = wp_strip_all_tags(strip_shortcodes($stripped_slashes));
+  return $cleaned_content;
+}


### PR DESCRIPTION
# One line summary
Revert and fix push title/content logic, handle missing UTM params, and update outdated WordPress documentation links.

# Description
This update includes multiple changes aimed at improving functionality and maintaining accuracy:

- **Reverted push notification logic**: Adjusted to set the push title to the site name and the push content to the post title. This reverts to pre-3 behavior.
- **Handled missing UTM parameters**: Fixed an issue where the absence of UTM parameters could trigger warnings about undefined array keys.
- **Updated WordPress documentation links**: Replaced outdated links with the consolidated `/wordpress` URL structure for better accessibility and relevance.

These changes address notification formatting, error handling, and documentation accuracy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/340)
<!-- Reviewable:end -->
