### PR TITLE
feat: allow users to define custom post types

### DIFF
--- a/v3/onesignal-admin/onesignal-admin.js
+++ b/v3/onesignal-admin/onesignal-admin.js
@@ -3,6 +3,8 @@ window.addEventListener("DOMContentLoaded", () => {
   const sendToMobileInfoDiv = document.querySelector(".mobile-app .information");
   const utmParamsHelpIcon = document.querySelector(".utm-params .help");
   const utmParamsInfoDiv = document.querySelector(".utm-params .information");
+  const customPostTypesHelpIcon = document.querySelector(".custom-post-types .help");
+  const customPostTypesInfoDiv = document.querySelector(".custom-post-types .information");
 
   const setupToggleAction = (helpIcon, infoDiv) => {
     if (helpIcon && infoDiv) {
@@ -15,6 +17,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
   setupToggleAction(sendToMobileHelpIcon, sendToMobileInfoDiv);
   setupToggleAction(utmParamsHelpIcon, utmParamsInfoDiv);
+  setupToggleAction(customPostTypesHelpIcon, customPostTypesInfoDiv);
 });
 
 window.addEventListener("DOMContentLoaded", () => {
@@ -24,13 +27,15 @@ window.addEventListener("DOMContentLoaded", () => {
   const autoSendCheckbox = document.querySelector("#auto-send");
   const sendToMobileCheckbox = document.querySelector("#send-to-mobile");
   const saveButton = document.querySelector("#save-settings-button");
+  const customPostTypesInput = document.querySelector("#custom-post-types");
 
-  if (appIdInput && apiKeyInput && autoSendCheckbox && sendToMobileCheckbox && utmInput && saveButton) {
+  if (appIdInput && apiKeyInput && autoSendCheckbox && sendToMobileCheckbox && utmInput && saveButton && customPostTypesInput) {
     const initialAppId = appIdInput.value;
     const initialApiKey = apiKeyInput.value;
     const initialUtmInput = utmInput.value;
     const initialAutoSend = autoSendCheckbox.checked;
     const initialSendToMobile = sendToMobileCheckbox.checked;
+    const initialCustomPostTypes = customPostTypesInput.value;
 
     function isValidUUID(uuid) {
       const uuidRegex =
@@ -60,8 +65,9 @@ window.addEventListener("DOMContentLoaded", () => {
       const utmChanged = utmInput.value !== initialUtmInput;
       const autoSendChanged = autoSendCheckbox.checked !== initialAutoSend;
       const sendToMobileChanged = sendToMobileCheckbox.checked !== initialSendToMobile;
+      const customPostTypesChanged = customPostTypesInput.value !== initialCustomPostTypes;
 
-      return appIdChanged || apiKeyChanged || autoSendChanged || sendToMobileChanged || utmChanged;
+      return appIdChanged || apiKeyChanged || autoSendChanged || sendToMobileChanged || utmChanged || customPostTypesChanged;
     }
 
     function toggleSaveButton() {
@@ -90,7 +96,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
     autoSendCheckbox.addEventListener("change", toggleSaveButton);
     sendToMobileCheckbox.addEventListener("change", toggleSaveButton);
-
+    customPostTypesInput.addEventListener("input", toggleSaveButton);
     // Initial state on page load
     toggleSaveButton();
   }

--- a/v3/onesignal-admin/onesignal-admin.js
+++ b/v3/onesignal-admin/onesignal-admin.js
@@ -5,6 +5,8 @@ window.addEventListener("DOMContentLoaded", () => {
   const utmParamsInfoDiv = document.querySelector(".utm-params .information");
   const customPostTypesHelpIcon = document.querySelector(".custom-post-types .help");
   const customPostTypesInfoDiv = document.querySelector(".custom-post-types .information");
+  const notificationOnPostFromPluginHelpIcon = document.querySelector(".notification-on-post-from-plugin .help");
+  const notificationOnPostFromPluginInfoDiv = document.querySelector(".notification-on-post-from-plugin .information");
 
   const setupToggleAction = (helpIcon, infoDiv) => {
     if (helpIcon && infoDiv) {
@@ -18,6 +20,7 @@ window.addEventListener("DOMContentLoaded", () => {
   setupToggleAction(sendToMobileHelpIcon, sendToMobileInfoDiv);
   setupToggleAction(utmParamsHelpIcon, utmParamsInfoDiv);
   setupToggleAction(customPostTypesHelpIcon, customPostTypesInfoDiv);
+  setupToggleAction(notificationOnPostFromPluginHelpIcon, notificationOnPostFromPluginInfoDiv);
 });
 
 window.addEventListener("DOMContentLoaded", () => {
@@ -28,14 +31,16 @@ window.addEventListener("DOMContentLoaded", () => {
   const sendToMobileCheckbox = document.querySelector("#send-to-mobile");
   const saveButton = document.querySelector("#save-settings-button");
   const customPostTypesInput = document.querySelector("#custom-post-types");
+  const notificationOnPostFromPluginCheckbox = document.querySelector("#notification-on-post-from-plugin");
 
-  if (appIdInput && apiKeyInput && autoSendCheckbox && sendToMobileCheckbox && utmInput && saveButton && customPostTypesInput) {
+  if (appIdInput && apiKeyInput && autoSendCheckbox && sendToMobileCheckbox && utmInput && saveButton && customPostTypesInput && notificationOnPostFromPluginCheckbox) {
     const initialAppId = appIdInput.value;
     const initialApiKey = apiKeyInput.value;
     const initialUtmInput = utmInput.value;
     const initialAutoSend = autoSendCheckbox.checked;
     const initialSendToMobile = sendToMobileCheckbox.checked;
     const initialCustomPostTypes = customPostTypesInput.value;
+    const initialNotificationOnPostFromPlugin = notificationOnPostFromPluginCheckbox.checked;
 
     function isValidUUID(uuid) {
       const uuidRegex =
@@ -66,8 +71,9 @@ window.addEventListener("DOMContentLoaded", () => {
       const autoSendChanged = autoSendCheckbox.checked !== initialAutoSend;
       const sendToMobileChanged = sendToMobileCheckbox.checked !== initialSendToMobile;
       const customPostTypesChanged = customPostTypesInput.value !== initialCustomPostTypes;
+      const notificationOnPostFromPluginChanged = notificationOnPostFromPluginCheckbox.checked !== initialNotificationOnPostFromPlugin;
 
-      return appIdChanged || apiKeyChanged || autoSendChanged || sendToMobileChanged || utmChanged || customPostTypesChanged;
+      return appIdChanged || apiKeyChanged || autoSendChanged || sendToMobileChanged || utmChanged || customPostTypesChanged || notificationOnPostFromPluginChanged;
     }
 
     function toggleSaveButton() {
@@ -93,10 +99,11 @@ window.addEventListener("DOMContentLoaded", () => {
     });
 
     utmInput.addEventListener("input", toggleSaveButton);
-
     autoSendCheckbox.addEventListener("change", toggleSaveButton);
     sendToMobileCheckbox.addEventListener("change", toggleSaveButton);
     customPostTypesInput.addEventListener("input", toggleSaveButton);
+    notificationOnPostFromPluginCheckbox.addEventListener("change", toggleSaveButton);
+
     // Initial state on page load
     toggleSaveButton();
   }

--- a/v3/onesignal-admin/onesignal-admin.php
+++ b/v3/onesignal-admin/onesignal-admin.php
@@ -42,9 +42,13 @@ if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST') 
         $onesignal_settings['utm_additional_url_params'] = sanitize_text_field($_POST['utm_additional_url_params']);
     }
 
-    // Save the auto send notifications setting
-    $auto_send = isset($_POST['onesignal_auto_send']) ? 1 : 0;
-    $onesignal_settings['notification_on_post'] = $auto_send;
+      if (isset($_POST['allowed_custom_post_types'])) {
+          $onesignal_settings['allowed_custom_post_types'] = sanitize_text_field($_POST['allowed_custom_post_types']);
+      }
+
+      // Save the auto send notifications setting
+      $auto_send = isset($_POST['onesignal_auto_send']) ? 1 : 0;
+      $onesignal_settings['notification_on_post'] = $auto_send;
 
     // Save the mobile subscribers setting
     $send_to_mobile = isset($_POST['onesignal_send_to_mobile']) ? 1 : 0;
@@ -151,6 +155,31 @@ function onesignal_admin_page()
             </div>
             <input id="utm-params" type="text" placeholder="utm_medium=ppc&utm_source=adwords&utm_campaign=snow%20boots&utm_content=durable%20%snow%boots" name="utm_additional_url_params" value="<?php echo $utmParams; ?>">
         </div>
+      </div>
+
+      <?php
+        $oneSignalSettings = get_option('OneSignalWPSetting');
+        $customPostTypes = ''; // Default empty value
+
+        // Check if the settings are an array and if the key exists
+        if (is_array($oneSignalSettings) && isset($oneSignalSettings['allowed_custom_post_types'])) {
+            $customPostTypes = esc_attr($oneSignalSettings['allowed_custom_post_types']);
+        }
+        ?>
+      <br>
+      <div class="field custom-post-types">
+        <label>Additional Custom Post Types for Automatic Notifications Created From Plugins</label>
+        <div class="help" aria-label="More information">
+          <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+            <g fill="currentColor">
+              <path d="M8 0a8 8 0 108 8 8.009 8.009 0 00-8-8zm0 12.667a1 1 0 110-2 1 1 0 010 2zm1.067-4.054a.667.667 0 00-.4.612.667.667 0 01-1.334 0 2 2 0 011.2-1.834A1.333 1.333 0 106.667 6.17a.667.667 0 01-1.334 0 2.667 2.667 0 113.734 2.444z"></path>
+            </g>
+          </svg>
+        </div>
+        <div class="information" style="display: none;">
+            <p>Enter a comma-separated list of custom post type names. Anytime a post is published with one of the listed post types, a notification will be sent to all your users. <strong class='least-strong'>The setting</strong> <em>Automatically send a push notification when I publish a post from 3rd party plugins</em> <strong class='least-strong'>must be enabled for this feature to work</strong>."</p>
+        </div>
+        <input id="custom-post-types"type="text" placeholder="forum,reply,topic  (comma separated, no spaces between commas)" name="allowed_custom_post_types" value="<?php echo esc_attr($customPostTypes); ?>">
       </div>
 
       <!-- Auto Send Checkbox -->

--- a/v3/onesignal-admin/onesignal-admin.php
+++ b/v3/onesignal-admin/onesignal-admin.php
@@ -42,21 +42,21 @@ if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST') 
         $onesignal_settings['utm_additional_url_params'] = sanitize_text_field($_POST['utm_additional_url_params']);
     }
 
-      if (isset($_POST['allowed_custom_post_types'])) {
-          $onesignal_settings['allowed_custom_post_types'] = sanitize_text_field($_POST['allowed_custom_post_types']);
-      }
+    if (isset($_POST['allowed_custom_post_types'])) {
+        $onesignal_settings['allowed_custom_post_types'] = sanitize_text_field($_POST['allowed_custom_post_types']);
+    }
 
-      // Save the auto send notifications setting
-      $auto_send = isset($_POST['onesignal_auto_send']) ? 1 : 0;
-      $onesignal_settings['notification_on_post'] = $auto_send;
+    // Save the auto send notifications setting
+    $auto_send = isset($_POST['onesignal_auto_send']) ? 1 : 0;
+    $onesignal_settings['notification_on_post'] = $auto_send;
 
-      // Save the notification on post from plugin setting
-      $notification_on_post_from_plugin = isset($_POST['notification_on_post_from_plugin']) ? 1 : 0;
-      $onesignal_settings['notification_on_post_from_plugin'] = $notification_on_post_from_plugin;
+    // Save the notification on post from plugin setting
+    $notification_on_post_from_plugin = isset($_POST['notification_on_post_from_plugin']) ? 1 : 0;
+    $onesignal_settings['notification_on_post_from_plugin'] = $notification_on_post_from_plugin;
 
-      // Save the mobile subscribers setting
-      $send_to_mobile = isset($_POST['onesignal_send_to_mobile']) ? 1 : 0;
-      $onesignal_settings['send_to_mobile_platforms'] = $send_to_mobile;
+    // Save the mobile subscribers setting
+    $send_to_mobile = isset($_POST['onesignal_send_to_mobile']) ? 1 : 0;
+    $onesignal_settings['send_to_mobile_platforms'] = $send_to_mobile;
 
     update_option('OneSignalWPSetting', $onesignal_settings);
   }

--- a/v3/onesignal-admin/onesignal-admin.php
+++ b/v3/onesignal-admin/onesignal-admin.php
@@ -50,9 +50,13 @@ if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST') 
       $auto_send = isset($_POST['onesignal_auto_send']) ? 1 : 0;
       $onesignal_settings['notification_on_post'] = $auto_send;
 
-    // Save the mobile subscribers setting
-    $send_to_mobile = isset($_POST['onesignal_send_to_mobile']) ? 1 : 0;
-    $onesignal_settings['send_to_mobile_platforms'] = $send_to_mobile;
+      // Save the notification on post from plugin setting
+      $notification_on_post_from_plugin = isset($_POST['notification_on_post_from_plugin']) ? 1 : 0;
+      $onesignal_settings['notification_on_post_from_plugin'] = $notification_on_post_from_plugin;
+
+      // Save the mobile subscribers setting
+      $send_to_mobile = isset($_POST['onesignal_send_to_mobile']) ? 1 : 0;
+      $onesignal_settings['send_to_mobile_platforms'] = $send_to_mobile;
 
     update_option('OneSignalWPSetting', $onesignal_settings);
   }
@@ -190,6 +194,27 @@ function onesignal_admin_page()
           <span class="checkbox"></span>
           Automatically send notifications when a post is published or updated
         </label>
+      </div>
+
+      <!-- 3rd Party Plugins Checkbox -->
+      <div class="checkbox-wrapper notification-on-post-from-plugin">
+        <label for="notification-on-post-from-plugin">
+            <input id="notification-on-post-from-plugin" type="checkbox" name="notification_on_post_from_plugin" value="true"
+            <?php echo (get_option('OneSignalWPSetting')['notification_on_post_from_plugin'] ?? 0) == 1 ? 'checked' : ''; ?>
+            >
+            <span class="checkbox"></span>
+            Automatically send a push notification when I publish a post from 3<sup>rd</sup> party plugins
+        </label>
+        <div class="help" aria-label="More information">
+          <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+            <g fill="currentColor">
+              <path d="M8 0a8 8 0 108 8 8.009 8.009 0 00-8-8zm0 12.667a1 1 0 110-2 1 1 0 010 2zm1.067-4.054a.667.667 0 00-.4.612.667.667 0 01-1.334 0 2 2 0 011.2-1.834A1.333 1.333 0 106.667 6.17a.667.667 0 01-1.334 0 2.667 2.667 0 113.734 2.444z"></path>
+            </g>
+          </svg>
+        </div>
+        <div class="information" style="display: none;">
+          <p>If checked, when a post is created outside of WordPress's editor, a push notification will automatically be sent. Must be the built-in WordPress post type 'post' and the post must be published.</p>
+        </div>
       </div>
 
       <!-- Mobile App Checkbox -->


### PR DESCRIPTION
### Summary

Allows users to define custom post types via the plugin admin page.

### Description

Changes include:

- adding new input to the admin page
- persist field values to `onesignal_settings`
- toggle save button when custom post types are modified

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/341)
<!-- Reviewable:end -->
