### PR TITLE
feat: uncheck the "Send notification" checkbox when a post is published

### DIFF
--- a/v3/onesignal-metabox/onesignal-metabox.js
+++ b/v3/onesignal-metabox/onesignal-metabox.js
@@ -32,4 +32,25 @@ window.addEventListener("DOMContentLoaded", () => {
     setDisplay(customiseWrap, customisePost.checked);
     setDisabled(customiseWrapChild, !customisePost.checked);
   });
+
+  // Watch for the Publish button to be added to the DOM
+  const observer = new MutationObserver((mutations, obs) => {
+    const publishButton = document.querySelector('.editor-post-publish-button__button');
+
+    if (publishButton) {
+      publishButton.addEventListener('click', function() {
+        setTimeout(() => {
+          if (sendPost && sendPost.checked) {
+            sendPost.click();
+          }
+        }, 1000);
+      });
+      obs.disconnect(); // Stop observing once we've found and handled the button
+    }
+  });
+
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true
+  });
 });

--- a/v3/onesignal-metabox/onesignal-metabox.js
+++ b/v3/onesignal-metabox/onesignal-metabox.js
@@ -40,8 +40,6 @@ window.addEventListener("DOMContentLoaded", () => {
 
   const editorStore = wp.data.select("core/editor");
 
-  // Track previous save state to prevent multiple checks
-  let previousIsSaving = false;
   let checkingNotification = false;
 
   // Subscribe to post status changes
@@ -52,16 +50,13 @@ window.addEventListener("DOMContentLoaded", () => {
 
     // Only proceed if we're transitioning from "not saving" to "saving"
     // This prevents multiple triggers during the same save operation
-    if (!isAutosaving && isSaving && !previousIsSaving && currentStatus === "publish") {
-      // Check if notification should be sent
+    if (!isAutosaving && isSaving && currentStatus === "publish") {
+      // Check if we should poll for notification status
       if (sendPost.checked && !checkingNotification) {
         checkingNotification = true;
         pollNotificationStatus();
       }
     }
-
-    // Update the previous save state, this is to prevent multiple triggers during the same save operation
-    previousIsSaving = isSaving;
   });
 
   /**
@@ -141,7 +136,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
         sendPost.checked = false;
         updateUI();
-        return;
+        break;
       }
 
       attempts++;

--- a/v3/onesignal-metabox/onesignal-metabox.js
+++ b/v3/onesignal-metabox/onesignal-metabox.js
@@ -65,17 +65,14 @@ window.addEventListener("DOMContentLoaded", () => {
    * @returns {Promise<boolean>} True if notification was sent successfully, false otherwise
    */
   async function checkNotificationStatus() {
-    // Get the current post ID from WordPress editor store
     const postId = editorStore.getCurrentPostId();
 
-    // Create form data for the AJAX request
     const formData = new FormData();
     formData.append('action', 'check_onesignal_notification'); // 'action' tells WordPress which AJAX handler to use (wp_ajax_check_onesignal_notification)
     formData.append('post_id', postId); // Pass the post ID to check notification status for this specific post
     formData.append('_ajax_nonce', ajax_object.nonce); // Add security nonce to prevent CSRF attacks
 
     try {
-      // Use the AJAX URL localized in PHP via wp_localize_script
       const response = await fetch(ajax_object.ajaxurl, {
         method: 'POST',
         credentials: 'same-origin',
@@ -86,8 +83,8 @@ window.addEventListener("DOMContentLoaded", () => {
       // Return the success status (true/false)
       return data.success;
     } catch (error) {
-      // If anything fails, assume notification wasn't sent
-      console.log('something went wrong', error)
+      console.error('OneSignal status check error:', error);
+      // If anything fails, assume the notification wasn't sent
       return false;
     }
   }
@@ -99,9 +96,9 @@ window.addEventListener("DOMContentLoaded", () => {
    */ 
   async function resetNotificationStatus() {
     const resetFormData = new FormData();
-    resetFormData.append('action', 'reset_onesignal_status');
-    resetFormData.append('post_id', editorStore.getCurrentPostId());
-    resetFormData.append('_ajax_nonce', ajax_object.nonce);
+    resetFormData.append('action', 'reset_onesignal_status'); // 'action' tells WordPress which AJAX handler to use (wp_ajax_reset_onesignal_status)
+    resetFormData.append('post_id', editorStore.getCurrentPostId()); // Pass the post ID to reset notification status for this specific post
+    resetFormData.append('_ajax_nonce', ajax_object.nonce); // Add security nonce to prevent CSRF attacks
 
     try {
       const resetResponse = await fetch(ajax_object.ajaxurl, {
@@ -110,7 +107,6 @@ window.addEventListener("DOMContentLoaded", () => {
         body: resetFormData
       });
       const resetData = await resetResponse.json();
-      console.log('OneSignal status reset:', resetData);
     } catch (error) {
       console.error('OneSignal status reset error:', error);
     }
@@ -129,7 +125,6 @@ window.addEventListener("DOMContentLoaded", () => {
 
     while (attempts < maxAttempts) {
       const sent = await checkNotificationStatus();
-      console.log('OneSignal poll attempt', attempts + 1, 'result:', sent);
 
       if (sent) {
         await resetNotificationStatus();
@@ -143,7 +138,6 @@ window.addEventListener("DOMContentLoaded", () => {
       await new Promise(resolve => setTimeout(resolve, 1500));
     }
 
-    console.log('OneSignal polling timed out');
     checkingNotification = false;
   }
 });

--- a/v3/onesignal-metabox/onesignal-metabox.js
+++ b/v3/onesignal-metabox/onesignal-metabox.js
@@ -20,50 +20,43 @@ window.addEventListener("DOMContentLoaded", () => {
     children.forEach((child) => (child.disabled = disabled));
   }
 
-  setDisplay(optionsWrap, sendPost.checked);
-  setDisplay(customiseWrap, customisePost.checked);
-  setDisabled(customiseWrapChild, !customisePost.checked);
-
-  sendPost.addEventListener("change", () => {
+  function updateUI() {
     setDisplay(optionsWrap, sendPost.checked);
-  });
-
-  customisePost.addEventListener("change", () => {
     setDisplay(customiseWrap, customisePost.checked);
     setDisabled(customiseWrapChild, !customisePost.checked);
-  });
+  }
 
-  // make sure WordPress editor and API are available
-  if (typeof wp === 'undefined' || !wp.data || !wp.data.select) {
-    console.warn('wp.data is not available.');
+  // init UI state
+  updateUI();
+
+  sendPost.addEventListener("change", updateUI);
+  customisePost.addEventListener("change", updateUI);
+
+  // Make sure WordPress editor and API are available
+  if (typeof wp === "undefined" || !wp.data || !wp.data.select) {
+    console.warn("wp.data is not available.");
     return;
   }
 
-  const editorStore = wp.data.select('core/editor');
+  const editorStore = wp.data.select("core/editor");
 
-  // track initial state of checkbox
-  const osUpdateCheckbox = document.querySelector('#os_update');
-  const wasCheckedInitially = osUpdateCheckbox ? osUpdateCheckbox.checked : false;
+  // Track previous post status to detect changes
+  let previousStatus = editorStore.getCurrentPostAttribute("status");
 
-  // track previous post status to detect changes
-  let previousStatus = editorStore.getCurrentPostAttribute('status');
-
-  // subscribe to state changes
   wp.data.subscribe(() => {
-    const currentStatus = editorStore.getCurrentPostAttribute('status');
+    const currentStatus = editorStore.getCurrentPostAttribute("status");
 
-    // check if the post status changed to "publish"
-    if (previousStatus !== currentStatus && currentStatus === 'publish') {
-        previousStatus = currentStatus;
+    // Check if the post status changed to "publish"
+    if (previousStatus !== currentStatus && currentStatus === "publish") {
+      previousStatus = currentStatus;
 
-        if (wasCheckedInitially) {
-            // uncheck the os_update checkbox
-            if (osUpdateCheckbox && osUpdateCheckbox.checked) {
-                osUpdateCheckbox.checked = false;
-            }
-        }
+      // Uncheck the checkbox and update the UI
+      if (sendPost.checked) {
+        sendPost.checked = false;
+        updateUI(); // Ensure the UI reflects the checkbox state
+      }
     } else {
-        previousStatus = currentStatus;
+      previousStatus = currentStatus;
     }
   });
 });

--- a/v3/onesignal-metabox/onesignal-metabox.php
+++ b/v3/onesignal-metabox/onesignal-metabox.php
@@ -48,9 +48,12 @@ function onesignal_metabox($post)
   <label for="os_update">
   <input type="checkbox" name="os_update" id="os_update"
        <?php
+       $post_status = get_post_status($post->ID);
+       $default_enabled = get_option('OneSignalWPSetting')['notification_on_post'] ?? 0;
+
        $os_update_checked = isset($os_meta['os_update'])
            ? $os_meta['os_update'] == 'on'
-           : (get_option('OneSignalWPSetting')['notification_on_post'] ?? 0) == 1;
+           : ($default_enabled == 1 && $post_status !== 'publish');
 
        echo $os_update_checked ? 'checked' : '';
        ?>>

--- a/v3/onesignal-metabox/onesignal-metabox.php
+++ b/v3/onesignal-metabox/onesignal-metabox.php
@@ -99,16 +99,26 @@ Send notification when post is published or updated
 add_action('admin_print_styles-post.php', 'onesignal_meta_files');
 add_action('admin_print_styles-post-new.php', 'onesignal_meta_files');
 
-function onesignal_meta_files()
-{
+function onesignal_meta_files() {
   $cache_buster = ceil(time() / 3600); // updates every hour
   wp_enqueue_script(
     'onesignal_metabox_js',
     plugins_url('onesignal-metabox.js', __FILE__),
-    array(),
+    ['wp-data'],
     $cache_buster,
     true // load in the footer for performance
   );
+
+  // Make PHP data available to our JavaScript
+  wp_localize_script(
+    'onesignal_metabox_js',
+    'ajax_object',
+    array(
+      'ajaxurl' => admin_url('admin-ajax.php'),
+      'nonce' => wp_create_nonce('onesignal_notification_nonce')
+    )
+  );
+
   wp_enqueue_style(
     'onesignal_metabox_css',
     plugins_url('onesignal-metabox.css', __FILE__),

--- a/v3/onesignal-notification.php
+++ b/v3/onesignal-notification.php
@@ -16,18 +16,7 @@ function check_notification_status($request) {
     return rest_ensure_response(['sent' => (bool)$status]);
 }
 
-// Register the REST API endpoint
-add_action('rest_api_init', function () {
-    register_rest_route('onesignal/v1', '/notification-status/(?P<post_id>\d+)', array(
-        'methods' => 'GET',
-        'callback' => 'check_notification_status',
-        'permission_callback' => function() {
-            return current_user_can('edit_posts');
-        }
-    ));
-});
-
-// Add the admin-ajax handler
+// Add the admin-ajax handler to check the notification status
 add_action('wp_ajax_check_onesignal_notification', function() {
     if (!current_user_can('edit_posts')) {
         wp_send_json_error('Unauthorized');
@@ -51,148 +40,129 @@ function reset_onesignal_notification_status() {
         wp_send_json_error('Invalid post ID');
     }
 
-    error_log('OneSignal Debug - Resetting notification status for post ' . $post_id);
     store_notification_status($post_id, false);
     wp_send_json_success(array('message' => 'Notification status reset'));
 }
 
-function log_me($message) {
-      if (WP_DEBUG === true) {
-          if (is_array($message) || is_object($message)) {
-              error_log(print_r($message, true));
-          } else {
-              error_log($message);
-          }
-    }
-}
-
 // Function to schedule notification
-function onesignal_schedule_notification($new_status, $old_status, $post)
-{
+function onesignal_schedule_notification($new_status, $old_status, $post) {
     if (($new_status === 'publish') || ($new_status === 'future')) {
-        error_log('OneSignal Debug - Start notification process');
-        error_log('OneSignal Debug - Initial status: ' . var_export(get_post_meta($post->ID, '_onesignal_notification_sent', true), true));
-        
         $onesignal_wp_settings = get_option("OneSignalWPSetting");
 
         // check if update is on.
         $update = !empty($_POST['os_update']) ? $_POST['os_update'] : $post->os_update;
 
-        error_log('OneSignal Debug - Update flag: ' . var_export($update, true));
         store_notification_status($post->ID, false);
 
         // Only reset status if we're going to send a notification
-        if (!empty($update)) {
-            // Reset status to false before sending
-            store_notification_status($post->ID, false);
-            error_log('OneSignal Debug - After reset status: ' . var_export(get_post_meta($post->ID, '_onesignal_notification_sent', true), true));
+        if (empty($update)) {
+            return;
+        }
 
-            // set api params
-            $title = !empty($_POST['os_title']) ? sanitize_text_field($_POST['os_title']) : decode_entities(get_bloginfo('name'));
-            $content = !empty($_POST['os_content']) ? sanitize_text_field($_POST['os_content']) : $post->post_title;
-            $excerpt = sanitize_content_for_excerpt($content);
-            $segment = $_POST['os_segment'] ?? 'All';
-            $config_utm_additional_url_params = $onesignal_wp_settings['utm_additional_url_params'] ?? '';
 
-            $url = get_permalink($post->ID);
-            if (!empty($config_utm_additional_url_params)) {
-              // validate and encode the URL parameters
-              $params = urlencode($config_utm_additional_url_params);
-              $url = $url . (strpos($url, '?') === false ? '?' : '&') . $params;
-            }
+        // Reset status to false before sending
+        store_notification_status($post->ID, false);
 
-            $apiKeyType = onesignal_get_api_key_type();
-            $authorizationHeader = $apiKeyType === "Rich"
-                ? 'Key ' . get_option('OneSignalWPSetting')['app_rest_api_key']
-                : 'Basic ' . get_option('OneSignalWPSetting')['app_rest_api_key'];
+        // set api params
+        $title = !empty($_POST['os_title']) ? sanitize_text_field($_POST['os_title']) : decode_entities(get_bloginfo('name'));
+        $content = !empty($_POST['os_content']) ? sanitize_text_field($_POST['os_content']) : $post->post_title;
+        $excerpt = sanitize_content_for_excerpt($content);
+        $segment = $_POST['os_segment'] ?? 'All';
+        $config_utm_additional_url_params = $onesignal_wp_settings['utm_additional_url_params'] ?? '';
 
-            $args = array(
-                'headers' => array(
-                    'Authorization' => $authorizationHeader,
-                    'accept' => 'application/json',
-                    'content-type' => 'application/json',
-                ),
-                'body' => json_encode(array(
-                    'app_id' => get_option('OneSignalWPSetting')['app_id'],
-                    'headings' => array('en' => $title),
-                    'contents' => array('en' => $excerpt),
-                    'included_segments' => array($segment),
-                    'web_push_topic' => str_replace(' ', '-', strtolower($segment)),
-                    'isAnyWeb' => true,
-                )),
-            );
+        $url = get_permalink($post->ID);
+        if (!empty($config_utm_additional_url_params)) {
+        // validate and encode the URL parameters
+        $params = urlencode($config_utm_additional_url_params);
+        $url = $url . (strpos($url, '?') === false ? '?' : '&') . $params;
+        }
 
-            $fields = json_decode($args['body'], true);
+        $apiKeyType = onesignal_get_api_key_type();
+        $authorizationHeader = $apiKeyType === "Rich"
+            ? 'Key ' . get_option('OneSignalWPSetting')['app_rest_api_key']
+            : 'Basic ' . get_option('OneSignalWPSetting')['app_rest_api_key'];
 
-            // Conditionally send or schedule
-            $postDate = new DateTime('now', new DateTimeZone('UTC'));
-            $sendDate = new DateTime($post->post_date_gmt, new DateTimeZone('UTC'));
+        $args = array(
+            'headers' => array(
+                'Authorization' => $authorizationHeader,
+                'accept' => 'application/json',
+                'content-type' => 'application/json',
+            ),
+            'body' => json_encode(array(
+                'app_id' => get_option('OneSignalWPSetting')['app_id'],
+                'headings' => array('en' => $title),
+                'contents' => array('en' => $excerpt),
+                'included_segments' => array($segment),
+                'web_push_topic' => str_replace(' ', '-', strtolower($segment)),
+                'isAnyWeb' => true,
+            )),
+        );
 
-            if ($sendDate > $postDate) {
-                // Schedule the notification to be sent in the future
-                $fields['send_after'] = $sendDate->format('Y-m-d H:i:s e');
-            }
+        $fields = json_decode($args['body'], true);
 
-            // Conditionally include mobile parameters
-            if (get_option('OneSignalWPSetting')['send_to_mobile_platforms'] && get_option('OneSignalWPSetting')['send_to_mobile_platforms'] == 1) {
-                $fields['isIos'] = true;
-                $fields['isAndroid'] = true;
-                $fields['isHuawei'] = true;
-                $fields['isWP_WNS'] = true;
-                if (!empty($_POST['os_mobile_url'])) {
-                    $fields['app_url'] = $_POST['os_mobile_url'];
-                    $fields['web_url'] = get_permalink($post->ID);
-                } else {
-                    $fields['url'] = $url;
-                }
+        // Conditionally send or schedule
+        $postDate = new DateTime('now', new DateTimeZone('UTC'));
+        $sendDate = new DateTime($post->post_date_gmt, new DateTimeZone('UTC'));
+
+        if ($sendDate > $postDate) {
+            // Schedule the notification to be sent in the future
+            $fields['send_after'] = $sendDate->format('Y-m-d H:i:s e');
+        }
+
+        // Conditionally include mobile parameters
+        if (get_option('OneSignalWPSetting')['send_to_mobile_platforms'] && get_option('OneSignalWPSetting')['send_to_mobile_platforms'] == 1) {
+            $fields['isIos'] = true;
+            $fields['isAndroid'] = true;
+            $fields['isHuawei'] = true;
+            $fields['isWP_WNS'] = true;
+            if (!empty($_POST['os_mobile_url'])) {
+                $fields['app_url'] = $_POST['os_mobile_url'];
+                $fields['web_url'] = get_permalink($post->ID);
             } else {
                 $fields['url'] = $url;
             }
-            // Set notification images based on the post's featured image
-            if (has_post_thumbnail($post->ID)) {
-                // Get the post thumbnail ID
-                $post_thumbnail_id = get_post_thumbnail_id($post->ID);
-
-                // Retrieve image URLs for different sizes
-                $thumbnail_size_url = wp_get_attachment_image_src($post_thumbnail_id, array(192, 192), true)[0];
-                $large_size_url = wp_get_attachment_image_src($post_thumbnail_id, 'large', true)[0];
-
-                // Assign image URLs to notification fields
-                $fields['firefox_icon'] =  $thumbnail_size_url;
-                $fields['chrome_web_icon'] =  $thumbnail_size_url;
-                $fields['chrome_web_image'] = $large_size_url;
-            }
-
-            // Include any fields from onesignal_send_notification filter
-            if (has_filter('onesignal_send_notification')) {
-                $fields = apply_filters('onesignal_send_notification', $fields, $post->ID);
-            }
-
-            $args['body'] = json_encode($fields);
-
-            // Make the API request and log errors
-            if (defined('REST_REQUEST') && REST_REQUEST) return;
-            $response = wp_remote_post('https://onesignal.com/api/v1/notifications', $args);
-            
-            // Store the final status based on the response
-            $success = false;
-            if (!is_wp_error($response)) {
-                $response_code = wp_remote_retrieve_response_code($response);
-                $body = json_decode(wp_remote_retrieve_body($response), true);
-                $success = $response_code === 200 && !empty($body['id']);
-                error_log('OneSignal Debug - Response code: ' . $response_code);
-                error_log('OneSignal Debug - Response body: ' . wp_remote_retrieve_body($response));
-            } else {
-                error_log('OneSignal Debug - WP Error: ' . $response->get_error_message());
-            }
-            
-            // Store the final status
-            store_notification_status($post->ID, $success);
-            error_log('OneSignal Debug - Final status: ' . var_export(get_post_meta($post->ID, '_onesignal_notification_sent', true), true));
         } else {
-            error_log('OneSignal Debug - Update not enabled, returning');
+            $fields['url'] = $url;
         }
-    } else {
-        log_me("                DID NOT SEND NOTIFICATION           ");
+        // Set notification images based on the post's featured image
+        if (has_post_thumbnail($post->ID)) {
+            // Get the post thumbnail ID
+            $post_thumbnail_id = get_post_thumbnail_id($post->ID);
+
+            // Retrieve image URLs for different sizes
+            $thumbnail_size_url = wp_get_attachment_image_src($post_thumbnail_id, array(192, 192), true)[0];
+            $large_size_url = wp_get_attachment_image_src($post_thumbnail_id, 'large', true)[0];
+
+            // Assign image URLs to notification fields
+            $fields['firefox_icon'] =  $thumbnail_size_url;
+            $fields['chrome_web_icon'] =  $thumbnail_size_url;
+            $fields['chrome_web_image'] = $large_size_url;
+        }
+
+        // Include any fields from onesignal_send_notification filter
+        if (has_filter('onesignal_send_notification')) {
+            $fields = apply_filters('onesignal_send_notification', $fields, $post->ID);
+        }
+
+        $args['body'] = json_encode($fields);
+
+        // Make the API request and log errors
+        if (defined('REST_REQUEST') && REST_REQUEST) return;
+        $response = wp_remote_post('https://onesignal.com/api/v1/notifications', $args);
+
+        // Store the final status based on the response
+        $success = false;
+
+        // Check if the notification was sent successfully
+        if (!is_wp_error($response)) {
+            $response_code = wp_remote_retrieve_response_code($response);
+            $body = json_decode(wp_remote_retrieve_body($response), true);
+            $success = $response_code === 200 && !empty($body['id']);
+        } else {
+            error_log('Notification failed: ' . $response->get_error_message());
+        }
+
+        // Store the final status
+        store_notification_status($post->ID, $success);
     }
 }

--- a/v3/onesignal-notification.php
+++ b/v3/onesignal-notification.php
@@ -16,40 +16,6 @@ function check_notification_status($request) {
     return rest_ensure_response(['sent' => (bool)$status]);
 }
 
-/**
- * Enqueues JavaScript files and localizes data for the OneSignal metabox
- * Only loads on post edit screens to prevent unnecessary script loading
- */
-function onesignal_enqueue_admin_scripts() {
-    // Only load on post edit screens
-    $screen = get_current_screen();
-    if (!$screen || !in_array($screen->base, ['post', 'post-new'])) {
-        return;
-    }
-
-    // Register and enqueue our JavaScript file
-    wp_enqueue_script(
-        'onesignal-metabox',                                                            // Unique handle for the script
-        plugins_url('/onesignal-metabox/onesignal-metabox.js', __FILE__),               // Path to the script
-        ['wp-data'],                                                                    // Dependencies
-        filemtime(plugin_dir_path(__FILE__) . 'onesignal-metabox/onesignal-metabox.js'),// Dynamic version number
-        true                                                                            // Load in footer
-    );
-
-    // Make PHP data available to our JavaScript
-    wp_localize_script(
-        'onesignal-metabox',                                           // Same handle as above
-        'ajax_object',                                                 // JavaScript object name
-        array(
-            'ajaxurl' => admin_url('admin-ajax.php'),                  // URL for AJAX requests
-            'nonce' => wp_create_nonce('onesignal_notification_nonce') // Security token
-        )
-    );
-}
-
-// Add the action to enqueue the script
-add_action('admin_enqueue_scripts', 'onesignal_enqueue_admin_scripts');
-
 // Register the REST API endpoint
 add_action('rest_api_init', function () {
     register_rest_route('onesignal/v1', '/notification-status/(?P<post_id>\d+)', array(
@@ -75,130 +41,158 @@ add_action('wp_ajax_check_onesignal_notification', function() {
 // Register the notification function, called when a post status changes
 add_action('transition_post_status', 'onesignal_schedule_notification', 10, 3);
 
+// Add a handler for resetting notification status
+add_action('wp_ajax_reset_onesignal_status', 'reset_onesignal_notification_status');
+function reset_onesignal_notification_status() {
+    check_ajax_referer('onesignal_notification_nonce', '_ajax_nonce');
+
+    $post_id = isset($_POST['post_id']) ? intval($_POST['post_id']) : 0;
+    if (!$post_id) {
+        wp_send_json_error('Invalid post ID');
+    }
+
+    error_log('OneSignal Debug - Resetting notification status for post ' . $post_id);
+    store_notification_status($post_id, false);
+    wp_send_json_success(array('message' => 'Notification status reset'));
+}
+
+function log_me($message) {
+      if (WP_DEBUG === true) {
+          if (is_array($message) || is_object($message)) {
+              error_log(print_r($message, true));
+          } else {
+              error_log($message);
+          }
+    }
+}
+
 // Function to schedule notification
 function onesignal_schedule_notification($new_status, $old_status, $post)
 {
-  if (($new_status === 'publish') || ($new_status === 'future')) {
+    if (($new_status === 'publish') || ($new_status === 'future')) {
+        error_log('OneSignal Debug - Start notification process');
+        error_log('OneSignal Debug - Initial status: ' . var_export(get_post_meta($post->ID, '_onesignal_notification_sent', true), true));
+        
         $onesignal_wp_settings = get_option("OneSignalWPSetting");
 
         // check if update is on.
         $update = !empty($_POST['os_update']) ? $_POST['os_update'] : $post->os_update;
 
-        // Store initial status as false
+        error_log('OneSignal Debug - Update flag: ' . var_export($update, true));
         store_notification_status($post->ID, false);
 
-        // do not send notification if not enabled
-        if (empty($update)) {
-            return;
-        }
+        // Only reset status if we're going to send a notification
+        if (!empty($update)) {
+            // Reset status to false before sending
+            store_notification_status($post->ID, false);
+            error_log('OneSignal Debug - After reset status: ' . var_export(get_post_meta($post->ID, '_onesignal_notification_sent', true), true));
 
-        // set api params
-        $title = !empty($_POST['os_title']) ? sanitize_text_field($_POST['os_title']) : decode_entities(get_bloginfo('name'));
-        $content = !empty($_POST['os_content']) ? sanitize_text_field($_POST['os_content']) : $post->post_title;
-        $excerpt = sanitize_content_for_excerpt($content);
-        $segment = $_POST['os_segment'] ?? 'All';
-        $config_utm_additional_url_params = $onesignal_wp_settings['utm_additional_url_params'] ?? '';
+            // set api params
+            $title = !empty($_POST['os_title']) ? sanitize_text_field($_POST['os_title']) : decode_entities(get_bloginfo('name'));
+            $content = !empty($_POST['os_content']) ? sanitize_text_field($_POST['os_content']) : $post->post_title;
+            $excerpt = sanitize_content_for_excerpt($content);
+            $segment = $_POST['os_segment'] ?? 'All';
+            $config_utm_additional_url_params = $onesignal_wp_settings['utm_additional_url_params'] ?? '';
 
-        $url = get_permalink($post->ID);
-        if (!empty($config_utm_additional_url_params)) {
-          // validate and encode the URL parameters
-          $params = urlencode($config_utm_additional_url_params);
-          $url = $url . (strpos($url, '?') === false ? '?' : '&') . $params;
-        }
+            $url = get_permalink($post->ID);
+            if (!empty($config_utm_additional_url_params)) {
+              // validate and encode the URL parameters
+              $params = urlencode($config_utm_additional_url_params);
+              $url = $url . (strpos($url, '?') === false ? '?' : '&') . $params;
+            }
 
-        $apiKeyType = onesignal_get_api_key_type();
-        $authorizationHeader = $apiKeyType === "Rich"
-            ? 'Key ' . get_option('OneSignalWPSetting')['app_rest_api_key']
-            : 'Basic ' . get_option('OneSignalWPSetting')['app_rest_api_key'];
+            $apiKeyType = onesignal_get_api_key_type();
+            $authorizationHeader = $apiKeyType === "Rich"
+                ? 'Key ' . get_option('OneSignalWPSetting')['app_rest_api_key']
+                : 'Basic ' . get_option('OneSignalWPSetting')['app_rest_api_key'];
 
-        $args = array(
-            'headers' => array(
-                'Authorization' => $authorizationHeader,
-                'accept' => 'application/json',
-                'content-type' => 'application/json',
-            ),
-            'body' => json_encode(array(
-                'app_id' => get_option('OneSignalWPSetting')['app_id'],
-                'headings' => array('en' => $title),
-                'contents' => array('en' => $excerpt),
-                'included_segments' => array($segment),
-                'web_push_topic' => str_replace(' ', '-', strtolower($segment)),
-                'isAnyWeb' => true,
-            )),
-        );
+            $args = array(
+                'headers' => array(
+                    'Authorization' => $authorizationHeader,
+                    'accept' => 'application/json',
+                    'content-type' => 'application/json',
+                ),
+                'body' => json_encode(array(
+                    'app_id' => get_option('OneSignalWPSetting')['app_id'],
+                    'headings' => array('en' => $title),
+                    'contents' => array('en' => $excerpt),
+                    'included_segments' => array($segment),
+                    'web_push_topic' => str_replace(' ', '-', strtolower($segment)),
+                    'isAnyWeb' => true,
+                )),
+            );
 
-        $fields = json_decode($args['body'], true);
+            $fields = json_decode($args['body'], true);
 
-        // Conditionally send or schedule
-        $postDate = new DateTime('now', new DateTimeZone('UTC'));
-        $sendDate = new DateTime($post->post_date_gmt, new DateTimeZone('UTC'));
+            // Conditionally send or schedule
+            $postDate = new DateTime('now', new DateTimeZone('UTC'));
+            $sendDate = new DateTime($post->post_date_gmt, new DateTimeZone('UTC'));
 
-        if ($sendDate > $postDate) {
-            // Schedule the notification to be sent in the future
-            $fields['send_after'] = $sendDate->format('Y-m-d H:i:s e');
-        }
+            if ($sendDate > $postDate) {
+                // Schedule the notification to be sent in the future
+                $fields['send_after'] = $sendDate->format('Y-m-d H:i:s e');
+            }
 
-        // Conditionally include mobile parameters
-        if (get_option('OneSignalWPSetting')['send_to_mobile_platforms'] && get_option('OneSignalWPSetting')['send_to_mobile_platforms'] == 1) {
-            $fields['isIos'] = true;
-            $fields['isAndroid'] = true;
-            $fields['isHuawei'] = true;
-            $fields['isWP_WNS'] = true;
-            if (!empty($_POST['os_mobile_url'])) {
-                $fields['app_url'] = $_POST['os_mobile_url'];
-                $fields['web_url'] = get_permalink($post->ID);
+            // Conditionally include mobile parameters
+            if (get_option('OneSignalWPSetting')['send_to_mobile_platforms'] && get_option('OneSignalWPSetting')['send_to_mobile_platforms'] == 1) {
+                $fields['isIos'] = true;
+                $fields['isAndroid'] = true;
+                $fields['isHuawei'] = true;
+                $fields['isWP_WNS'] = true;
+                if (!empty($_POST['os_mobile_url'])) {
+                    $fields['app_url'] = $_POST['os_mobile_url'];
+                    $fields['web_url'] = get_permalink($post->ID);
+                } else {
+                    $fields['url'] = $url;
+                }
             } else {
                 $fields['url'] = $url;
             }
-        } else {
-            $fields['url'] = $url;
-        }
-        // Set notification images based on the post's featured image
-        if (has_post_thumbnail($post->ID)) {
-            // Get the post thumbnail ID
-            $post_thumbnail_id = get_post_thumbnail_id($post->ID);
+            // Set notification images based on the post's featured image
+            if (has_post_thumbnail($post->ID)) {
+                // Get the post thumbnail ID
+                $post_thumbnail_id = get_post_thumbnail_id($post->ID);
 
-            // Retrieve image URLs for different sizes
-            $thumbnail_size_url = wp_get_attachment_image_src($post_thumbnail_id, array(192, 192), true)[0];
-            $large_size_url = wp_get_attachment_image_src($post_thumbnail_id, 'large', true)[0];
+                // Retrieve image URLs for different sizes
+                $thumbnail_size_url = wp_get_attachment_image_src($post_thumbnail_id, array(192, 192), true)[0];
+                $large_size_url = wp_get_attachment_image_src($post_thumbnail_id, 'large', true)[0];
 
-            // Assign image URLs to notification fields
-            $fields['firefox_icon'] =  $thumbnail_size_url;
-            $fields['chrome_web_icon'] =  $thumbnail_size_url;
-            $fields['chrome_web_image'] = $large_size_url;
-        }
-
-        // Include any fields from onesignal_send_notification filter
-        if (has_filter('onesignal_send_notification')) {
-            $fields = apply_filters('onesignal_send_notification', $fields, $post->ID);
-        }
-
-        $args['body'] = json_encode($fields);
-
-        // Make the API request and log errors
-        if (defined('REST_REQUEST') && REST_REQUEST) return;
-        $response = wp_remote_post('https://onesignal.com/api/v1/notifications', $args);
-
-        // Store the notification status based on the response
-        $success = false;
-        if (!is_wp_error($response)) {
-            $response_code = wp_remote_retrieve_response_code($response);
-            $body = json_decode(wp_remote_retrieve_body($response), true);
-
-            // Check if the notification was sent successfully
-            $success = $response_code === 200 && !empty($body['id']);
-
-            if ($success) {
-                error_log('OneSignal notification sent successfully: ' . $body['id']);
-            } else {
-                error_log('OneSignal notification failed. Response code: ' . $response_code);
-                error_log('Response body: ' . wp_remote_retrieve_body($response));
+                // Assign image URLs to notification fields
+                $fields['firefox_icon'] =  $thumbnail_size_url;
+                $fields['chrome_web_icon'] =  $thumbnail_size_url;
+                $fields['chrome_web_image'] = $large_size_url;
             }
-        } else {
-            error_log('OneSignal notification failed: ' . $response->get_error_message());
-        }
 
-        // Store the final status
-        store_notification_status($post->ID, $success);
+            // Include any fields from onesignal_send_notification filter
+            if (has_filter('onesignal_send_notification')) {
+                $fields = apply_filters('onesignal_send_notification', $fields, $post->ID);
+            }
+
+            $args['body'] = json_encode($fields);
+
+            // Make the API request and log errors
+            if (defined('REST_REQUEST') && REST_REQUEST) return;
+            $response = wp_remote_post('https://onesignal.com/api/v1/notifications', $args);
+            
+            // Store the final status based on the response
+            $success = false;
+            if (!is_wp_error($response)) {
+                $response_code = wp_remote_retrieve_response_code($response);
+                $body = json_decode(wp_remote_retrieve_body($response), true);
+                $success = $response_code === 200 && !empty($body['id']);
+                error_log('OneSignal Debug - Response code: ' . $response_code);
+                error_log('OneSignal Debug - Response body: ' . wp_remote_retrieve_body($response));
+            } else {
+                error_log('OneSignal Debug - WP Error: ' . $response->get_error_message());
+            }
+            
+            // Store the final status
+            store_notification_status($post->ID, $success);
+            error_log('OneSignal Debug - Final status: ' . var_export(get_post_meta($post->ID, '_onesignal_notification_sent', true), true));
+        } else {
+            error_log('OneSignal Debug - Update not enabled, returning');
+        }
+    } else {
+        log_me("                DID NOT SEND NOTIFICATION           ");
     }
 }


### PR DESCRIPTION
## Description

After a post is published or updated, uncheck the "Send notification when post is published or updated" checkbox. This is to prevent unintentionally sending subsequent notifications if say, a post author or other plugin were to edit the post. With this change, plugin consumers will need to opt into sending notifications to users after the post is initially published. 

## Details

On first attempt, we tried simply unchecking the "Send notification" checkbox when a user saves a post. This quickly proved to be an issue as the checkbox state is used in determining whether a OneSignal notification request should be make. A "quick and dirty" way to get around this is to add a wait between when a post is saved and when the checkbox is unchecked. Unsurprisingly, this is not a good approach as external factors (such as network speeds) can cause these actions to happen out of sync. A better approach would ideally wait to uncheck the box once we can guarantee that the notification action has successfully completed, which requires coordination between the client and server.

This PR achieves this effect by:
- Adding a "notification status" global that tracks if a notification has been successfully sent yet.
- Creating an [internal endpoint](https://developer.wordpress.org/plugins/javascript/ajax/) that is available to both the client and server via a property on the global object.
	- This endpoint incorporates security measures so that only users with permission to edit the post can create push notification requests.
- Polling this endpoint once every 1.5 seconds whenever a post is saved, which will return the current notification status.
- Unchecking the "Send notification" checkbox once the poll indicates that a notification has been sent, guaranteeing that these steps are taken in the correct order.
- Resetting the notification status metadata field as a final cleanup step.

## Demo

### v2 Demo
https://github.com/user-attachments/assets/54a622d1-10a0-4256-9c9a-a80297045d25

### v3 Demo Gutenberg

https://github.com/user-attachments/assets/a0ddf630-fe98-46f2-a560-136ee0fa819a

### v3 Demo Classic

https://github.com/user-attachments/assets/9593f1a9-f027-4043-97a5-343ea387c379

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/342)
<!-- Reviewable:end -->
	