### PR TITLE
Add cache-busting query param when loading CSS and JS scripts

### DIFF
--- a/v3/onesignal-admin/onesignal-admin.php
+++ b/v3/onesignal-admin/onesignal-admin.php
@@ -16,8 +16,14 @@ add_action('admin_enqueue_scripts', 'admin_files');
 
 function admin_files()
 {
-  wp_enqueue_script('onesignal_admin_js', plugins_url('onesignal-admin.js', __FILE__));
-  wp_enqueue_style('style', plugins_url('onesignal-admin.css', __FILE__), array(), time());
+  $cache_buster = ceil(time() / 3600); // updates every hour
+  wp_enqueue_script(
+    'onesignal_admin_js',
+    plugins_url('onesignal-admin.js', __FILE__),
+    array(),
+    $cache_buster
+  );
+  wp_enqueue_style('style', plugins_url('onesignal-admin.css', __FILE__), array(), $cache_buster);
 }
 
 if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/v3/onesignal-metabox/onesignal-metabox.php
+++ b/v3/onesignal-metabox/onesignal-metabox.php
@@ -98,11 +98,21 @@ add_action('admin_print_styles-post-new.php', 'onesignal_meta_files');
 
 function onesignal_meta_files()
 {
-  wp_enqueue_script('onesignal_metabox_js', plugins_url('onesignal-metabox.js', __FILE__));
-  wp_enqueue_style('onesignal_metabox_css', plugins_url('onesignal-metabox.css', __FILE__), array(), time());
+  $cache_buster = ceil(time() / 3600); // updates every hour
+  wp_enqueue_script(
+    'onesignal_metabox_js',
+    plugins_url('onesignal-metabox.js', __FILE__),
+    array(),
+    $cache_buster,
+    true // load in the footer for performance
+  );
+  wp_enqueue_style(
+    'onesignal_metabox_css',
+    plugins_url('onesignal-metabox.css', __FILE__),
+    array(),
+    $cache_buster
+  );
 }
-
-
 
 // Store meta data
 add_action('save_post', 'onesignal_save_meta', 10);


### PR DESCRIPTION
Motivation: depending on each user's site caching settings, they may not be getting updates to JS or CSS files as new versions come out.

Adding cache-busting helps fix that issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/343)
<!-- Reviewable:end -->
