### PR TITLE
feat: uncheck the "Send notification" checkbox when a post is published

### DIFF
--- a/v3/onesignal-metabox/onesignal-metabox.js
+++ b/v3/onesignal-metabox/onesignal-metabox.js
@@ -20,16 +20,16 @@ window.addEventListener("DOMContentLoaded", () => {
     children.forEach((child) => (child.disabled = disabled));
   }
 
-  setDisplay(optionsWrap, sendPost.checked);
-  setDisplay(customiseWrap, customisePost.checked);
-  setDisabled(customiseWrapChild, !customisePost.checked);
-
-  sendPost.addEventListener("change", () => {
+  function updateUI() {
     setDisplay(optionsWrap, sendPost.checked);
-  });
-
-  customisePost.addEventListener("change", () => {
     setDisplay(customiseWrap, customisePost.checked);
     setDisabled(customiseWrapChild, !customisePost.checked);
+  }
+
+  updateUI();
+
+  sendPost.addEventListener("change", updateUI);
+  customisePost.addEventListener("change", updateUI);
+
   });
 });

--- a/v3/onesignal-metabox/onesignal-metabox.js
+++ b/v3/onesignal-metabox/onesignal-metabox.js
@@ -31,5 +31,32 @@ window.addEventListener("DOMContentLoaded", () => {
   sendPost.addEventListener("change", updateUI);
   customisePost.addEventListener("change", updateUI);
 
+  // Make sure WordPress editor and API are available
+  if (typeof wp === "undefined" || !wp.data || !wp.data.select) {
+    console.warn("wp.data is not available.");
+    return;
+  }
+
+  let wasSaving = false;
+
+  /*
+  * Uncheck the "Send notification when post is published or updated" input whenever the post is published
+  * This is to prevent users from accidentally sending notifications on subsequent updates
+  * Instead, the user needs to opt-in again to send a notification when a post is updated
+  */
+  wp.data.subscribe(() => {
+    const isSaving = wp.data.select('core/editor').isSavingPost();
+    const postStatus = wp.data.select('core/editor').getCurrentPost().status;
+
+    // Check if the post has finished saving successfully and is published
+    if (wasSaving && !isSaving && postStatus === 'publish') {
+      if (sendPost && sendPost.checked) {
+        sendPost.checked = false;
+        updateUI();
+      }
+    }
+
+    // reset state for the next check
+    wasSaving = isSaving;
   });
 });


### PR DESCRIPTION
## Description

After a post is published or updated, uncheck the "Send notification when post is published or updated" checkbox. This is to prevent unintentionally sending subsequent notifications if say, a post author or other plugin were to save an edit to the post. With this change, plugin consumers will need to opt into sending notifications to users after the post is initially published. 

## Details

This PR offers compatibility for both the Gutenberg and Classic editors.

### Gutenberg Editor

Implementation utilizes the [core editor](https://developer.wordpress.org/block-editor/reference-guides/data/data-core-editor/) APIs to track the current post's publish status. This is to ensure that the input is only unchecked once all server-side notification actions have completed.

### Classic Editor

The classic editor implementation tackles two challenges:
- there are less WordPress-native APIs e.g. `isPostSaving` and `getCurrentPost().status`
- after saving a post, the editor will perform a full refresh

To get around this, we will persist the publish state in session storage.

## Demo

### v2 Demo
https://github.com/user-attachments/assets/54a622d1-10a0-4256-9c9a-a80297045d25

### v3 Demo Gutenberg

https://github.com/user-attachments/assets/92a6fddf-5866-4e3e-bc3c-67de8bc53429

### v3 Demo Classic

https://github.com/user-attachments/assets/1be99ccd-18e9-4618-ab3e-9d323ea02808

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/348)
<!-- Reviewable:end -->
