### PR TITLE
fix: add more robust check for if the Gutenberg editor is loaded

### DIFF
--- a/v3/onesignal-metabox/onesignal-metabox.js
+++ b/v3/onesignal-metabox/onesignal-metabox.js
@@ -41,8 +41,8 @@ window.addEventListener("DOMContentLoaded", () => {
   if (isGutenbergEditorLoaded()) {
     // Gutenberg editor
     wp.data.subscribe(() => {
-      const isSaving = wp.data.select('core/editor').isSavingPost();
-      const postStatus = wp.data.select('core/editor').getCurrentPost().status;
+      const isSaving = wp?.data?.select('core/editor')?.isSavingPost();
+      const postStatus = wp?.data?.select('core/editor')?.getCurrentPost()?.status;
 
       // Check if the post has finished saving successfully and is published
       if (wasSaving && !isSaving && postStatus === 'publish') {

--- a/v3/onesignal-metabox/onesignal-metabox.js
+++ b/v3/onesignal-metabox/onesignal-metabox.js
@@ -38,7 +38,7 @@ window.addEventListener("DOMContentLoaded", () => {
   * This is to prevent users from accidentally sending notifications on subsequent updates
   * Instead, the user needs to opt-in again to send a notification when a post is updated
   */
-  if (wp?.data?.select) {
+  if (isGutenbergEditorLoaded()) {
     // Gutenberg editor
     wp.data.subscribe(() => {
       const isSaving = wp.data.select('core/editor').isSavingPost();
@@ -79,3 +79,7 @@ window.addEventListener("DOMContentLoaded", () => {
     });
   }
 });
+
+function isGutenbergEditorLoaded() {
+  return ( wp?.data !== undefined && wp?.data?.select( 'core/editor' ) !== undefined );
+}


### PR DESCRIPTION
## Description

Resolves an issue where the plugin does not work in the Classic editor.

## Details

Since the release of [v3.1.0](https://github.com/OneSignal/OneSignal-WordPress-Plugin/releases/tag/v3.1.0), some users have reported errors in the browser console when the plugin loads into the Classic editor. Based on reports, the error specifically occurs when using this plugin with the [Yoast SEO](https://wordpress.org/plugins/wordpress-seo/) v24.4 plugin. The specific error emitted is:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'isSavingPost')
```

When #348 was introduced, it included branching logic depending on which editor (Gutenberg vs Classic) the user publishes their posts from. In theory, `isSavingPost` should not be invoked in the Classic editor as it is Gutenberg-specific. This PR adds more robust checks to ensure that the plugin loads in the correct editor and barring that, it should still fail gracefully.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/350)
<!-- Reviewable:end -->
