### PR TITLE
fix: only run form submit logic when saving admin settings

### DIFF
--- a/v3/onesignal-admin/onesignal-admin.php
+++ b/v3/onesignal-admin/onesignal-admin.php
@@ -27,7 +27,7 @@ function admin_files()
 }
 
 if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST') {
-  if (isset($_POST["submit"])) {
+  if (isset($_POST["submit"]) && $_POST["submit"] === "Save Settings") {
     // Get existing settings with default values
     $onesignal_settings = get_option('OneSignalWPSetting', onesignal_get_default_settings());
 


### PR DESCRIPTION
Addresses an issue where checkbox toggles on the admin page revert back to `unchecked`. Although users would check these inputs and save their settings, the value would often revert back after a while or when logging out of the site and back in.

This was due to the form submission code executing even though the admin "Save Settings" button was not pressed. It seems that WordPress will submit page forms for different reasons, which can incorrectly trigger our "Save Settings" logic and inadvertently overwrite values.

This commit adds a more strict check so that submission logic is only run when the value is explicitly set to `Save Settings`. In other words, only when the user presses the "Save Settings" button on the page.

Follow up to [#346](https://github.com/OneSignal/OneSignal-WordPress-Plugin/pull/346)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/353)
<!-- Reviewable:end -->
