### PR TITLE
fix: disable sending notifications from pages by default

### DIFF
--- a/v3/onesignal-helpers.php
+++ b/v3/onesignal-helpers.php
@@ -34,3 +34,17 @@ function sanitize_content_for_excerpt($content) {
   $cleaned_content = wp_strip_all_tags(strip_shortcodes($stripped_slashes));
   return $cleaned_content;
 }
+
+function onesignal_is_post_type_allowed($post_type) {
+    if ($post_type === 'post') {
+        return true;
+    }
+
+    $onesignal_wp_settings = get_option("OneSignalWPSetting");
+    if (empty($onesignal_wp_settings['allowed_custom_post_types'])) {
+        return false;
+    }
+
+    $allowed_post_types = array_map('trim', explode(',', $onesignal_wp_settings['allowed_custom_post_types']));
+    return in_array($post_type, $allowed_post_types);
+}

--- a/v3/onesignal-metabox/onesignal-metabox.php
+++ b/v3/onesignal-metabox/onesignal-metabox.php
@@ -7,11 +7,24 @@ add_action('add_meta_boxes', 'onesignal_add_metabox');
 
 function onesignal_add_metabox()
 {
-  add_meta_box(
-    'onesignal_metabox', // metabox ID
-    'OneSignal Push Notifications', // title
-    'onesignal_metabox', // callback function
-  );
+  $current_post_type = get_post_type();
+
+  if (
+    $current_post_type === 'post' ||
+    onesignal_should_show_metabox($current_post_type)
+  ) {
+    add_meta_box(
+      'onesignal_metabox', // metabox ID
+      'OneSignal Push Notifications', // title
+      'onesignal_metabox', // callback function
+    );
+  }
+}
+
+function onesignal_should_show_metabox($post_type) {
+    $onesignal_wp_settings = get_option("OneSignalWPSetting");
+    $allowed_post_types = array_map('trim', explode(',', $onesignal_wp_settings['allowed_custom_post_types']));
+    return in_array($post_type, $allowed_post_types);
 }
 
 // Render the meta box

--- a/v3/onesignal-metabox/onesignal-metabox.php
+++ b/v3/onesignal-metabox/onesignal-metabox.php
@@ -9,22 +9,13 @@ function onesignal_add_metabox()
 {
   $current_post_type = get_post_type();
 
-  if (
-    $current_post_type === 'post' ||
-    onesignal_should_show_metabox($current_post_type)
-  ) {
+  if (onesignal_is_post_type_allowed($current_post_type)) {
     add_meta_box(
       'onesignal_metabox', // metabox ID
       'OneSignal Push Notifications', // title
       'onesignal_metabox', // callback function
     );
   }
-}
-
-function onesignal_should_show_metabox($post_type) {
-    $onesignal_wp_settings = get_option("OneSignalWPSetting");
-    $allowed_post_types = array_map('trim', explode(',', $onesignal_wp_settings['allowed_custom_post_types']));
-    return in_array($post_type, $allowed_post_types);
 }
 
 // Render the meta box

--- a/v3/onesignal-notification.php
+++ b/v3/onesignal-notification.php
@@ -12,6 +12,19 @@ function onesignal_schedule_notification($new_status, $old_status, $post)
   if (($new_status === 'publish') || ($new_status === 'future')) {
         $onesignal_wp_settings = get_option("OneSignalWPSetting");
 
+        // Get the current post type
+        $current_post_type = get_post_type($post->ID);
+
+        // Split the allowed post types string into an array and trim whitespace
+        $allowed_post_types = array_map('trim', explode(',', $onesignal_wp_settings['allowed_custom_post_types']));
+
+        error_log('custom post types: ' . $current_post_type . ' ' . print_r($allowed_post_types, true) . ' ' . in_array($current_post_type, $allowed_post_types));
+
+        // Check if current post type is in the allowed list
+        if (!in_array($current_post_type, $allowed_post_types)) {
+            return;
+        }
+
         // check if update is on.
         $update = !empty($_POST['os_update']) ? $_POST['os_update'] : $post->os_update;
 

--- a/v3/onesignal-notification.php
+++ b/v3/onesignal-notification.php
@@ -13,8 +13,6 @@ function onesignal_is_notification_allowed($post_id) {
     $current_post_type = get_post_type($post_id);
     $allowed_post_types = array_map('trim', explode(',', $onesignal_wp_settings['allowed_custom_post_types']));
 
-    // error_log('custom post types: ' . $current_post_type . ' ' . print_r($allowed_post_types, true) . ' ' . in_array($current_post_type, $allowed_post_types));
-
     return in_array($current_post_type, $allowed_post_types);
 }
 
@@ -23,9 +21,9 @@ function onesignal_schedule_notification($new_status, $old_status, $post)
 {
     if (($new_status === 'publish') || ($new_status === 'future')) {
         $onesignal_wp_settings = get_option("OneSignalWPSetting");
-        error_log('onesignal_wp_settings: ' . print_r($onesignal_wp_settings, true));
 
-        if (!onesignal_is_notification_allowed($post->ID)) {
+        $current_post_type = get_post_type($post->ID);
+        if ($current_post_type !== 'post' && !onesignal_is_notification_allowed($post->ID)) {
             return;
         }
 

--- a/v3/onesignal-notification.php
+++ b/v3/onesignal-notification.php
@@ -6,16 +6,6 @@ defined('ABSPATH') or die('This page may not be accessed directly.');
 // Register the notification function, called when a post status changes
 add_action('transition_post_status', 'onesignal_schedule_notification', 10, 3);
 
-// Check if notifications are allowed for a post type
-function onesignal_is_notification_allowed($post_id) {
-    $onesignal_wp_settings = get_option("OneSignalWPSetting");
-
-    $current_post_type = get_post_type($post_id);
-    $allowed_post_types = array_map('trim', explode(',', $onesignal_wp_settings['allowed_custom_post_types']));
-
-    return in_array($current_post_type, $allowed_post_types);
-}
-
 // Function to schedule notification
 function onesignal_schedule_notification($new_status, $old_status, $post)
 {
@@ -23,7 +13,7 @@ function onesignal_schedule_notification($new_status, $old_status, $post)
         $onesignal_wp_settings = get_option("OneSignalWPSetting");
 
         $current_post_type = get_post_type($post->ID);
-        if ($current_post_type !== 'post' && !onesignal_is_notification_allowed($post->ID)) {
+        if (!onesignal_is_post_type_allowed($current_post_type)) {
             return;
         }
 


### PR DESCRIPTION
Users have mentioned that sending notifications by default from pages is a jarring experience. This PR treats WordPress pages as a custom post type so that the plugin metabox does not appear on the editor unless the user specifically opts into it.

In order to see the metabox, users will need to add `page` to the list of custom post types from the plugin admin page.


## Demo

### Gutenberg Editor

https://github.com/user-attachments/assets/7974fe28-dc95-42a0-b153-f4c692ed3ca1

### Classic Editor

https://github.com/user-attachments/assets/bc9fbc06-654f-4e46-b761-b666cdf55dfa


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/356)
<!-- Reviewable:end -->
