### PR TITLE
feat: allow users to opt into sending notification on WP pages

### DIFF
--- a/onesignal.php
+++ b/onesignal.php
@@ -39,13 +39,14 @@ if ($plugin_version === ONESIGNAL_VERSION_V3) {
 
     // Ensure migration is marked as complete after loading V3
     if (!$is_migrated) {
-        if(!$is_new_install && !isset($settings['notification_on_page'])) {
-            // Upgrade within v3 - enable notification_on_page for existing users
-            // This prevents breaking changes for users who were used to v2 behavior
-            $settings['notification_on_page'] = 1;
-            update_option('OneSignalWPSetting', $settings, 'no');
-        }
         update_option('onesignal_plugin_migrated', true);
+    }
+
+    if(!$is_new_install && !isset($settings['notification_on_page'])) {
+        // Upgrade within v3 - enable notification_on_page for existing users
+        // This prevents breaking changes for users who were used to v2 behavior
+        $settings['notification_on_page'] = 1;
+        update_option('OneSignalWPSetting', $settings, 'no');
     }
 } else {
     // Load V2 plugin files

--- a/onesignal.php
+++ b/onesignal.php
@@ -39,6 +39,12 @@ if ($plugin_version === ONESIGNAL_VERSION_V3) {
 
     // Ensure migration is marked as complete after loading V3
     if (!$is_migrated) {
+        if(!$is_new_install) {
+            // Upgrade within v3 - enable notification_on_page for existing users
+            // This prevents breaking changes for users who were used to v2 behavior
+            $settings['notification_on_page'] = 1;
+            update_option('OneSignalWPSetting', $settings, 'no');
+        }
         update_option('onesignal_plugin_migrated', true);
     }
 } else {

--- a/onesignal.php
+++ b/onesignal.php
@@ -39,7 +39,7 @@ if ($plugin_version === ONESIGNAL_VERSION_V3) {
 
     // Ensure migration is marked as complete after loading V3
     if (!$is_migrated) {
-        if(!$is_new_install) {
+        if(!$is_new_install && !isset($settings['notification_on_page'])) {
             // Upgrade within v3 - enable notification_on_page for existing users
             // This prevents breaking changes for users who were used to v2 behavior
             $settings['notification_on_page'] = 1;

--- a/v2/complete-migration.php
+++ b/v2/complete-migration.php
@@ -9,8 +9,8 @@ function onesignal_complete_migration()
             wp_die(__('Security check failed', 'onesignal-push'));
         }
 
-        // Set option for notification_on_page updates to true
-        // This is to prevent breaking changes for existing users migrating from v2 to v3
+        // Upgrade from v2 to v3 - enable notification_on_page for existing users
+        // This prevents breaking changes for users who were used to v2 behavior
         $settings = get_option('OneSignalWPSetting', array());
         $settings['notification_on_page'] = 1;
 

--- a/v2/complete-migration.php
+++ b/v2/complete-migration.php
@@ -9,6 +9,13 @@ function onesignal_complete_migration()
             wp_die(__('Security check failed', 'onesignal-push'));
         }
 
+        // Set option for notification_on_page updates to true
+        // This is to prevent breaking changes for existing users migrating from v2 to v3
+        $settings = get_option('OneSignalWPSetting', array());
+        $settings['notification_on_page'] = 1;
+
+        update_option('OneSignalWPSetting', $settings, 'no');
+
         // Mark the plugin as migrated
         update_option('onesignal_plugin_migrated', true);
 

--- a/v2/complete-migration.php
+++ b/v2/complete-migration.php
@@ -9,13 +9,6 @@ function onesignal_complete_migration()
             wp_die(__('Security check failed', 'onesignal-push'));
         }
 
-        // Upgrade from v2 to v3 - enable notification_on_page for existing users
-        // This prevents breaking changes for users who were used to v2 behavior
-        $settings = get_option('OneSignalWPSetting', array());
-        $settings['notification_on_page'] = 1;
-
-        update_option('OneSignalWPSetting', $settings, 'no');
-
         // Mark the plugin as migrated
         update_option('onesignal_plugin_migrated', true);
 

--- a/v3/onesignal-admin/onesignal-admin.js
+++ b/v3/onesignal-admin/onesignal-admin.js
@@ -32,8 +32,19 @@ window.addEventListener("DOMContentLoaded", () => {
   const saveButton = document.querySelector("#save-settings-button");
   const customPostTypesInput = document.querySelector("#custom-post-types");
   const notificationOnPostFromPluginCheckbox = document.querySelector("#notification-on-post-from-plugin");
+  const notificationOnPageCheckbox = document.querySelector("#auto-send-pages");
 
-  if (appIdInput && apiKeyInput && autoSendCheckbox && sendToMobileCheckbox && utmInput && saveButton && customPostTypesInput && notificationOnPostFromPluginCheckbox) {
+  const haveAllAdminInputsLoaded = appIdInput &&
+    apiKeyInput &&
+    autoSendCheckbox &&
+    sendToMobileCheckbox &&
+    utmInput &&
+    saveButton &&
+    customPostTypesInput &&
+    notificationOnPostFromPluginCheckbox &&
+    notificationOnPageCheckbox;
+
+  if (haveAllAdminInputsLoaded) {
     const initialAppId = appIdInput.value;
     const initialApiKey = apiKeyInput.value;
     const initialUtmInput = utmInput.value;
@@ -41,6 +52,7 @@ window.addEventListener("DOMContentLoaded", () => {
     const initialSendToMobile = sendToMobileCheckbox.checked;
     const initialCustomPostTypes = customPostTypesInput.value;
     const initialNotificationOnPostFromPlugin = notificationOnPostFromPluginCheckbox.checked;
+    const initialNotificationOnPage = notificationOnPageCheckbox.checked;
 
     function isValidUUID(uuid) {
       const uuidRegex =
@@ -72,8 +84,16 @@ window.addEventListener("DOMContentLoaded", () => {
       const sendToMobileChanged = sendToMobileCheckbox.checked !== initialSendToMobile;
       const customPostTypesChanged = customPostTypesInput.value !== initialCustomPostTypes;
       const notificationOnPostFromPluginChanged = notificationOnPostFromPluginCheckbox.checked !== initialNotificationOnPostFromPlugin;
+      const notificationOnPageChanged = notificationOnPageCheckbox.checked !== initialNotificationOnPage;
 
-      return appIdChanged || apiKeyChanged || autoSendChanged || sendToMobileChanged || utmChanged || customPostTypesChanged || notificationOnPostFromPluginChanged;
+      return appIdChanged ||
+        apiKeyChanged ||
+        autoSendChanged ||
+        sendToMobileChanged ||
+        utmChanged ||
+        customPostTypesChanged ||
+        notificationOnPostFromPluginChanged ||
+        notificationOnPageChanged;
     }
 
     function toggleSaveButton() {
@@ -103,6 +123,7 @@ window.addEventListener("DOMContentLoaded", () => {
     sendToMobileCheckbox.addEventListener("change", toggleSaveButton);
     customPostTypesInput.addEventListener("input", toggleSaveButton);
     notificationOnPostFromPluginCheckbox.addEventListener("change", toggleSaveButton);
+    notificationOnPageCheckbox.addEventListener("change", toggleSaveButton);
 
     // Initial state on page load
     toggleSaveButton();

--- a/v3/onesignal-admin/onesignal-admin.php
+++ b/v3/onesignal-admin/onesignal-admin.php
@@ -47,9 +47,13 @@ if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST') 
         $onesignal_settings['allowed_custom_post_types'] = sanitize_text_field($_POST['allowed_custom_post_types']);
     }
 
-    // Save the auto send notifications setting
+    // Save the auto send notifications setting for posts
     $auto_send = isset($_POST['onesignal_auto_send']) ? 1 : 0;
     $onesignal_settings['notification_on_post'] = $auto_send;
+
+    // Save the auto send notifications setting for pages
+    $auto_send_pages = isset($_POST['onesignal_auto_send_pages']) ? 1 : 0;
+    $onesignal_settings['notification_on_page'] = $auto_send_pages;
 
     // Save the notification on post from plugin setting
     $notification_on_post_from_plugin = isset($_POST['notification_on_post_from_plugin']) ? 1 : 0;
@@ -71,6 +75,7 @@ if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST') 
 function onesignal_get_default_settings() {
     return array(
         'notification_on_post' => 0,
+        'notification_on_page' => 0,
         'notification_on_post_from_plugin' => 0,
         'send_to_mobile_platforms' => 0
     );
@@ -209,6 +214,16 @@ function onesignal_admin_page()
                  <?php echo (!empty($settings['notification_on_post'])) ? 'checked' : ''; ?>>
           <span class="checkbox"></span>
           Automatically send notifications when a post is published or updated
+        </label>
+      </div>
+
+      <!-- Auto Send for Pages Checkbox -->
+      <div class="checkbox-wrapper auto-send-pages">
+        <label for="auto-send-pages">
+          <input id="auto-send-pages" type="checkbox" name="onesignal_auto_send_pages"
+                 <?php echo (!empty($settings['notification_on_page'])) ? 'checked' : ''; ?>>
+          <span class="checkbox"></span>
+          Automatically send notifications when a page is published or updated
         </label>
       </div>
 

--- a/v3/onesignal-helpers.php
+++ b/v3/onesignal-helpers.php
@@ -34,3 +34,11 @@ function sanitize_content_for_excerpt($content) {
   $cleaned_content = wp_strip_all_tags(strip_shortcodes($stripped_slashes));
   return $cleaned_content;
 }
+
+function onesignal_is_post_type_allowed($post_type) {
+    if ($post_type === 'post') return true;
+
+    $settings = get_option("OneSignalWPSetting");
+
+    if($post_type === 'page' && !empty($settings['notification_on_page'])) return true;
+}

--- a/v3/onesignal-metabox/onesignal-metabox.php
+++ b/v3/onesignal-metabox/onesignal-metabox.php
@@ -7,11 +7,23 @@ add_action('add_meta_boxes', 'onesignal_add_metabox');
 
 function onesignal_add_metabox()
 {
-  add_meta_box(
-    'onesignal_metabox', // metabox ID
-    'OneSignal Push Notifications', // title
-    'onesignal_metabox', // callback function
-  );
+  $current_post_type = get_post_type();
+  $settings = get_option("OneSignalWPSetting");
+
+  if ($current_post_type === 'post') {
+    add_meta_box(
+      'onesignal_metabox', // metabox ID
+      'OneSignal Push Notifications', // title
+      'onesignal_metabox', // callback function
+    );
+  }
+  else if ($current_post_type === 'page' && !empty($settings['notification_on_page'])) {
+    add_meta_box(
+      'onesignal_metabox', // metabox ID
+      'OneSignal Push Notifications', // title
+      'onesignal_metabox', // callback function
+    );
+  }
 }
 
 // Render the meta box

--- a/v3/onesignal-metabox/onesignal-metabox.php
+++ b/v3/onesignal-metabox/onesignal-metabox.php
@@ -8,16 +8,8 @@ add_action('add_meta_boxes', 'onesignal_add_metabox');
 function onesignal_add_metabox()
 {
   $current_post_type = get_post_type();
-  $settings = get_option("OneSignalWPSetting");
 
-  if ($current_post_type === 'post') {
-    add_meta_box(
-      'onesignal_metabox', // metabox ID
-      'OneSignal Push Notifications', // title
-      'onesignal_metabox', // callback function
-    );
-  }
-  else if ($current_post_type === 'page' && !empty($settings['notification_on_page'])) {
+  if (onesignal_is_post_type_allowed($current_post_type)) {
     add_meta_box(
       'onesignal_metabox', // metabox ID
       'OneSignal Push Notifications', // title


### PR DESCRIPTION
This PR adds a new admin configuration that will hide the plugin metabox from the editor in WordPress [pages](https://wordpress.com/support/pages/) unless toggled on. This is to support a strong default of not automatically sending notifications when a page is published/updated, as most users generally will not want to.

This PR also enables this toggle on by default for users migrating from v2 to v3. This is to offer backwards compatibility for how v2 published notifications on pages. For users starting from a fresh install, the toggle will be set to false by default.

## Demos

### Gutenberg Editor

https://github.com/user-attachments/assets/4d8db8bc-bd1a-4e79-9af9-140f2ab31aca

### Classic Editor

https://github.com/user-attachments/assets/dc96ba4a-1523-4955-9004-9b29fc3cd0d6


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/357)
<!-- Reviewable:end -->
