### PR TITLE
fix: hide metabox on non-allowed custom post types

### DIFF
--- a/v3/onesignal-helpers.php
+++ b/v3/onesignal-helpers.php
@@ -41,4 +41,9 @@ function onesignal_is_post_type_allowed($post_type) {
     $settings = get_option("OneSignalWPSetting");
 
     if($post_type === 'page' && !empty($settings['notification_on_page'])) return true;
+
+    if (empty($settings['allowed_custom_post_types'])) return false;
+
+    $allowed_post_types = array_map('trim', explode(',', $settings['allowed_custom_post_types']));
+    return in_array($post_type, $allowed_post_types);
 }

--- a/v3/onesignal-notification.php
+++ b/v3/onesignal-notification.php
@@ -9,7 +9,7 @@ add_action('transition_post_status', 'onesignal_schedule_notification', 10, 3);
 // Function to schedule notification
 function onesignal_schedule_notification($new_status, $old_status, $post)
 {
-  if (($new_status === 'publish') || ($new_status === 'future')) {
+    if (($new_status === 'publish') || ($new_status === 'future')) {
         $onesignal_wp_settings = get_option("OneSignalWPSetting");
 
         // check if update is on.


### PR DESCRIPTION
Prevents the plugin metabox from being rendered on custom post types by default. To enable it, users will need to add the post type name to a comma-delimited list under the Custom Post Types field.

## Demo

### Before

https://github.com/user-attachments/assets/a1bc5d88-a322-463a-be0c-243826c5d56e

### After


https://github.com/user-attachments/assets/5869969c-cfe6-496a-91a2-ae7306a9cd7c



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/358)
<!-- Reviewable:end -->
