### PR TITLE
chore(release): v3.2.0

### DIFF
--- a/onesignal.php
+++ b/onesignal.php
@@ -6,7 +6,7 @@ defined('ABSPATH') or die('This page may not be accessed directly.');
  * Plugin Name: OneSignal Push Notifications
  * Plugin URI: https://onesignal.com/
  * Description: Free web push notifications.
- * Version: 3.1.2
+ * Version: 3.2.0
  * Author: OneSignal
  * Author URI: https://onesignal.com
  * License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: OneSignal
 Donate link: https://onesignal.com
 Tags: push notification, push notifications, desktop notifications, mobile notifications, chrome push, android, android notification, android notifications, android push, desktop notification, firefox, firefox push, mobile, mobile notification, notification, notifications, notify, onesignal, push, push messages, safari, safari push, web push, chrome
 Requires at least: 3.8
-Tested up to: 6.7
-Stable tag: 3.1.2
+Tested up to: 6.8
+Stable tag: 3.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -63,6 +63,11 @@ OneSignal is trusted by over 1.8M+ developers and marketing strategists. We powe
 [youtube https://www.youtube.com/watch?v=q1mH2kCK7LQ]
 
 == Changelog ==
+
+= 3.2.0 =
+- Allow users to opt into sending notification on WP pages
+- Bug fix: hide metabox on non-allowed custom post types
+- Bug fix: use os_meta array instead of accessing from post data directly
 
 = 3.1.2 =
 - Bug fix: only run form submit logic when saving admin settings


### PR DESCRIPTION
## 3.2.0

### Features
- allow users to opt into sending notification on WP pages #357 

### Fixes
- hide metabox on non-allowed custom post types #358 
- use os_meta array instead of accessing from post data directly #359

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/360)
<!-- Reviewable:end -->
