### PR TITLE
chore: add github-to-asana workflows

### DIFF
--- a/.github/workflows/asana-add-comment.yml
+++ b/.github/workflows/asana-add-comment.yml
@@ -1,0 +1,47 @@
+name: Github --> Asana Add Comment Workflow
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+    steps:
+        - name: Get Asana Task Corresponding to Issue
+          env:
+            ISSUE_ID: ${{ github.event.issue.id }}
+            REPO_FULL_NAME: ${{ github.event.repository.full_name }}
+            WORKSPACE_ID: "780103692902078"
+          run: |
+            REPO_SCOPED_ISSUE_ID="$REPO_FULL_NAME#$ISSUE_ID"
+
+            curl --request GET \
+                 --url "https://app.asana.com/api/1.0/workspaces/$WORKSPACE_ID/tasks/search?opt_fields=notes&text=$REPO_SCOPED_ISSUE_ID&sort_by=modified_at&sort_ascending=false" \
+                 --header 'accept: application/json' \
+                 --header 'authorization: Bearer ${{ secrets.ASANA_PAT }}' \
+                 --output response.json
+            TASK_GID=$(jq -r '.data[0].gid' response.json)
+            echo "TASK_GID=$TASK_GID" >> $GITHUB_ENV
+        - name: Comment on Asana Task
+          env:
+            ISSUE_COMMENT: ${{ github.event.comment.body }}
+            COMMENTER_NAME: ${{ github.event.comment.user.login }}
+          run: |
+            BODY_DATA=$(jq -n \
+              --arg text "$ISSUE_COMMENT" \
+              --arg commenter_name "$COMMENTER_NAME" \
+              '{
+                "data": {
+                  "text": "\($commenter_name) left a comment:\n\n\($text)",
+                }
+              }')
+            curl --request POST \
+                 --url https://app.asana.com/api/1.0/tasks/$TASK_GID/stories \
+                 --header 'accept: application/json' \
+                 --header 'authorization: Bearer ${{ secrets.ASANA_PAT }}' \
+                 --header 'content-type: application/json' \
+                 --data "$BODY_DATA"

--- a/.github/workflows/asana-create-task.yml
+++ b/.github/workflows/asana-create-task.yml
@@ -1,0 +1,119 @@
+name: Github --> Asana Create Task Workflow
+
+on:
+  issues:
+    types: [opened]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+    steps:
+        - name: Create Asana task
+          env:
+            ISSUE_TITLE: ${{ github.event.issue.title }}
+            ISSUE_BODY: ${{ github.event.issue.body }}
+            ISSUE_HTML_URL: ${{ github.event.issue.html_url }}
+            ISSUE_ID: ${{ github.event.issue.id }}
+            ISSUE_NUMBER: ${{ github.event.issue.number }}
+            REPO_FULL_NAME: ${{ github.event.repository.full_name }}
+            SDK_PLATFORM_GROUP: "1208961704779581"
+            SDK_PLATFORM_GROUP_WEB: "1208961704779583"
+            SDK_PLATFORM: "1208961704779592"
+            SDK_PLATFORM_WORDPRESS: "1208961704779602"
+            DSA_PRIORITY: "1208779519954980"
+            DSA_PRIORITY_NO_PRIORITY: "1208779521616959"
+            DSA_STATUS: "1210103546117753"
+            DSA_STATUS_TRIAGE: "1210103546117756"
+            DSA_REPO_TICKET_URL: "1210347857768758"
+            WORKSPACE_ID: "780103692902078"
+            PROJECT_ID_GITHUB_AND_IMPORTANT_SDK_ISSUES: "1208970714650308"
+            PROJECT_ID_SDK_BACKLOG: "1208777198342772"
+          run: |
+            DATA_BODY=$(jq -n \
+              --arg title "$ISSUE_TITLE" \
+              --arg body "$ISSUE_BODY" \
+              --arg url "$ISSUE_HTML_URL" \
+              --arg id "$ISSUE_ID" \
+              --arg number "$ISSUE_NUMBER" \
+              --arg repo_full_name "$REPO_FULL_NAME" \
+              --arg sdk_platform_group "$SDK_PLATFORM_GROUP" \
+              --arg sdk_platform_group_web "$SDK_PLATFORM_GROUP_WEB" \
+              --arg sdk_platform "$SDK_PLATFORM" \
+              --arg sdk_platform_web "$SDK_PLATFORM_WORDPRESS" \
+              --arg dsa_priority "$DSA_PRIORITY" \
+              --arg dsa_priority_no_priority "$DSA_PRIORITY_NO_PRIORITY" \
+              --arg dsa_status "$DSA_STATUS" \
+              --arg dsa_status_triage "$DSA_STATUS_TRIAGE" \
+              --arg dsa_repo_ticket_url "$DSA_REPO_TICKET_URL" \
+              --arg workspace_id "$WORKSPACE_ID" \
+              --arg project_id_github_and_important_sdk_issues "$PROJECT_ID_GITHUB_AND_IMPORTANT_SDK_ISSUES" \
+              --arg project_id_sdk_backlog "$PROJECT_ID_SDK_BACKLOG" \
+              '{
+                "data": {
+                  "custom_fields": {
+                    $sdk_platform_group: $sdk_platform_group_web,
+                    $sdk_platform: $sdk_platform_wordpress,
+                    $dsa_priority: $dsa_priority_no_priority,
+                    $dsa_status: $dsa_status_triage,
+                    $dsa_repo_ticket_url: $url
+                  },
+                  "name": $title,
+                  "workspace": $workspace_id,
+                  "projects": [$project_id_github_and_important_sdk_issues, $project_id_sdk_backlog],
+                  "notes": "Issue ID: \($repo_full_name)#\($id)\nIssue number: \($number)\nCreated via GitHub Actions\n----\n\n\($body)"
+                }
+              }')
+
+            curl --request POST \
+                 --url https://app.asana.com/api/1.0/tasks?opt_pretty=true \
+                 --header 'accept: application/json' \
+                 --header 'authorization: Bearer ${{ secrets.ASANA_PAT }}' \
+                 --header 'content-type: application/json' \
+                 --data "$DATA_BODY" \
+                 --output response.json
+
+            TASK_GID=$(jq -r '.data.gid' response.json)
+            echo "TASK_GID=$TASK_GID" >> $GITHUB_ENV
+        - name: Move to "0 Unclassified" section in "Github & Important SDK Issues" project
+          env:
+            SECTION_ID_GITHUB_AND_IMPORTANT_SDK_ISSUES: "1208970755434051"
+          run: |
+              DATA_BODY=$(jq -n \
+                --arg task_gid "$TASK_GID" \
+                --arg section_id "$SECTION_ID_GITHUB_AND_IMPORTANT_SDK_ISSUES" \
+                '{
+                  "data": {
+                    "task": $task_gid,
+                    "insert_after": "null"
+                  }
+                }')
+
+              curl --request POST \
+              --url https://app.asana.com/api/1.0/sections/$section_id/addTask \
+              --header 'accept: application/json' \
+              --header 'authorization: Bearer ${{ secrets.ASANA_PAT }}' \
+              --header 'content-type: application/json' \
+              --data "$DATA_BODY"
+        - name: Move to "Untriaged" section in "SDK / Backlog" project
+          env:
+            SECTION_ID_SDK_BACKLOG: "1208899729378982"
+          run: |
+              DATA_BODY=$(jq -n \
+                --arg task_gid "$TASK_GID" \
+                --arg section_id "$SECTION_ID_SDK_BACKLOG" \
+                '{
+                  "data": {
+                    "task": $task_gid,
+                    "insert_after": "null"
+                  }
+                }')
+
+              curl --request POST \
+              --url https://app.asana.com/api/1.0/sections/$section_id/addTask \
+              --header 'accept: application/json' \
+              --header 'authorization: Bearer ${{ secrets.ASANA_PAT }}' \
+              --header 'content-type: application/json' \
+              --data "$DATA_BODY"

--- a/.github/workflows/asana-update-issue.yml
+++ b/.github/workflows/asana-update-issue.yml
@@ -1,0 +1,172 @@
+name: Github --> Asana Issue Updates Workflow
+
+on:
+  issues:
+    types: [edited, deleted, closed, reopened, assigned, unassigned, labeled, unlabeled, milestoned, demilestoned, pinned, unpinned, locked, unlocked, transferred]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+    steps:
+        - name: Get Asana Task Corresponding to Issue
+          env:
+            ISSUE_ID: ${{ github.event.issue.id }}
+            REPO_FULL_NAME: ${{ github.event.repository.full_name }}
+            WORKSPACE_ID: "780103692902078"
+          run: |
+            REPO_SCOPED_ISSUE_ID="$REPO_FULL_NAME#$ISSUE_ID"
+
+            curl --request GET \
+                 --url "https://app.asana.com/api/1.0/workspaces/$WORKSPACE_ID/tasks/search?opt_fields=notes&text=$REPO_SCOPED_ISSUE_ID&sort_by=modified_at&sort_ascending=false" \
+                 --header 'accept: application/json' \
+                 --header 'authorization: Bearer ${{ secrets.ASANA_PAT }}' \
+                 --output response.json
+            TASK_GID=$(jq -r '.data[0].gid' response.json)
+            echo "TASK_GID=$TASK_GID" >> $GITHUB_ENV
+        - name: Determine Action and Post to Asana
+          env:
+            ACTION_TYPE: ${{ github.event.action }}
+            ACTOR_NAME: ${{ github.event.sender.login }}
+            ISSUE_TITLE: ${{ github.event.issue.title }}
+            ISSUE_NUMBER: ${{ github.event.issue.number }}
+            ISSUE_STATE: ${{ github.event.issue.state }}
+          run: |
+            # Map GitHub action types to human-readable descriptions
+            case "$ACTION_TYPE" in
+              "edited")
+                ACTION_DESC="edited the issue"
+                ;;
+              "deleted")
+                ACTION_DESC="deleted the issue"
+                ;;
+              "closed")
+                ACTION_DESC="closed the issue"
+                ;;
+              "reopened")
+                ACTION_DESC="reopened the issue"
+                ;;
+              "assigned")
+                ACTION_DESC="assigned the issue"
+                ;;
+              "unassigned")
+                ACTION_DESC="unassigned the issue"
+                ;;
+              "labeled")
+                ACTION_DESC="added labels to the issue"
+                ;;
+              "unlabeled")
+                ACTION_DESC="removed labels from the issue"
+                ;;
+              "milestoned")
+                ACTION_DESC="added the issue to a milestone"
+                ;;
+              "demilestoned")
+                ACTION_DESC="removed the issue from a milestone"
+                ;;
+              "pinned")
+                ACTION_DESC="pinned the issue"
+                ;;
+              "unpinned")
+                ACTION_DESC="unpinned the issue"
+                ;;
+              "locked")
+                ACTION_DESC="locked the issue"
+                ;;
+              "unlocked")
+                ACTION_DESC="unlocked the issue"
+                ;;
+              "transferred")
+                ACTION_DESC="transferred the issue"
+                ;;
+              *)
+                ACTION_DESC="performed an action on the issue"
+                ;;
+            esac
+
+            # Add additional context for specific actions based on webhook payload
+            if [ "$ACTION_TYPE" = "assigned" ] && [ -n "${{ github.event.assignee.login }}" ]; then
+              ACTION_DESC="assigned the issue to ${{ github.event.assignee.login }}"
+            fi
+
+            if [ "$ACTION_TYPE" = "unassigned" ] && [ -n "${{ github.event.assignee.login }}" ]; then
+              ACTION_DESC="unassigned the issue from ${{ github.event.assignee.login }}"
+            fi
+
+            if [ "$ACTION_TYPE" = "labeled" ] && [ -n "${{ github.event.label.name }}" ]; then
+              LABEL_COLOR="${{ github.event.label.color }}"
+              ACTION_DESC="added label '${{ github.event.label.name }}' to the issue"
+              if [ -n "$LABEL_COLOR" ]; then
+                ACTION_DESC="$ACTION_DESC (color: #$LABEL_COLOR)"
+              fi
+            fi
+
+            if [ "$ACTION_TYPE" = "unlabeled" ] && [ -n "${{ github.event.label.name }}" ]; then
+              LABEL_COLOR="${{ github.event.label.color }}"
+              ACTION_DESC="removed label '${{ github.event.label.name }}' from the issue"
+              if [ -n "$LABEL_COLOR" ]; then
+                ACTION_DESC="$ACTION_DESC (color: #$LABEL_COLOR)"
+              fi
+            fi
+
+            if [ "$ACTION_TYPE" = "milestoned" ] && [ -n "${{ github.event.milestone.title }}" ]; then
+              MILESTONE_DUE_DATE="${{ github.event.milestone.due_on }}"
+              ACTION_DESC="added the issue to milestone '${{ github.event.milestone.title }}'"
+              if [ -n "$MILESTONE_DUE_DATE" ] && [ "$MILESTONE_DUE_DATE" != "null" ]; then
+                ACTION_DESC="$ACTION_DESC (due: $MILESTONE_DUE_DATE)"
+              fi
+            fi
+
+            if [ "$ACTION_TYPE" = "demilestoned" ] && [ -n "${{ github.event.milestone.title }}" ]; then
+              ACTION_DESC="removed the issue from milestone '${{ github.event.milestone.title }}'"
+            fi
+
+            if [ "$ACTION_TYPE" = "transferred" ] && [ -n "${{ github.event.changes.new_repository.full_name }}" ]; then
+              ACTION_DESC="transferred the issue to repository ${{ github.event.changes.new_repository.full_name }}"
+            fi
+
+            if [ "$ACTION_TYPE" = "edited" ] && [ -n "${{ github.event.changes.title.from }}" ]; then
+              OLD_TITLE="${{ github.event.changes.title.from }}"
+              NEW_TITLE="${{ github.event.issue.title }}"
+              ACTION_DESC="edited the issue title from '$OLD_TITLE' to '$NEW_TITLE'"
+            fi
+
+            echo "ACTION_DESC=$ACTION_DESC" >> $GITHUB_ENV
+
+            # Only proceed if we found a task
+            if [ "$TASK_GID" != "null" ] && [ -n "$TASK_GID" ]; then
+              # Create a more detailed message with additional context
+              MESSAGE_TEXT="$ACTOR_NAME performed an action: $ACTION_DESC"
+              
+              # Add issue state information for state changes
+              if [ "$ACTION_TYPE" = "closed" ] || [ "$ACTION_TYPE" = "reopened" ]; then
+                MESSAGE_TEXT=$(printf "%s\nIssue state: %s" "$MESSAGE_TEXT" "$ISSUE_STATE")
+              fi
+              
+              # Add repository information for transferred issues
+              if [ "$ACTION_TYPE" = "transferred" ]; then
+                REPO_NAME="${{ github.event.repository.full_name }}"
+                MESSAGE_TEXT=$(printf "%s\nFrom repository: %s" "$MESSAGE_TEXT" "$REPO_NAME")
+              fi
+              
+              MESSAGE_TEXT=$(printf "%s\n\nIssue: #%s - %s" "$MESSAGE_TEXT" "$ISSUE_NUMBER" "$ISSUE_TITLE")
+
+              BODY_DATA=$(jq -n \
+                --arg text "$MESSAGE_TEXT" \
+                '{
+                  "data": {
+                    "text": $text
+                  }
+                }')
+
+              curl --request POST \
+                   --url https://app.asana.com/api/1.0/tasks/$TASK_GID/stories \
+                   --header 'accept: application/json' \
+                   --header 'authorization: Bearer ${{ secrets.ASANA_PAT }}' \
+                   --header 'content-type: application/json' \
+                   --data "$BODY_DATA"
+            else
+              echo "No corresponding Asana task found for issue ID: $ISSUE_ID"
+            fi


### PR DESCRIPTION
# Description
## Summary
Adds three new GitHub Actions that will create/modify Asana tasks:
1. Create a new Asana task when a new GitHub issue is created
2. Add a comment to an existing Asana task when a GitHub user comments on an issue
3. Add a comment to an existing Asana task when any action is performed on a GitHub issue (e.g. assignee changed, labels added/removed, etc.)

## Details

### Motivation
This helps capture activity and potential bugs from this repo in Asana for better organization and project maintenance.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/363)
<!-- Reviewable:end -->
