### PR TITLE
Send notification meta checkbox

### DIFF
--- a/v3/onesignal-admin/onesignal-admin.php
+++ b/v3/onesignal-admin/onesignal-admin.php
@@ -104,7 +104,7 @@ function onesignal_admin_page()
     }
     ?>
     <form method="post">
-      <label for="appid">OneSignal App ID HELLLO</label>
+      <label for="appid">OneSignal App ID</label>
       <div class="input-with-icon">
         <input type="text" id="appid" name="onesignal_app_id"
               value="<?php echo esc_attr(get_option('OneSignalWPSetting')['app_id'] ?? ''); ?>" />

--- a/v3/onesignal-admin/onesignal-admin.php
+++ b/v3/onesignal-admin/onesignal-admin.php
@@ -104,7 +104,7 @@ function onesignal_admin_page()
     }
     ?>
     <form method="post">
-      <label for="appid">OneSignal App ID</label>
+      <label for="appid">OneSignal App ID HELLLO</label>
       <div class="input-with-icon">
         <input type="text" id="appid" name="onesignal_app_id"
               value="<?php echo esc_attr(get_option('OneSignalWPSetting')['app_id'] ?? ''); ?>" />
@@ -213,7 +213,7 @@ function onesignal_admin_page()
           <input id="auto-send" type="checkbox" name="onesignal_auto_send"
                  <?php echo (!empty($settings['notification_on_post'])) ? 'checked' : ''; ?>>
           <span class="checkbox"></span>
-          Automatically send notifications when a post is published or updated
+          Automatically send notifications when a post is published
         </label>
       </div>
 
@@ -223,7 +223,7 @@ function onesignal_admin_page()
           <input id="auto-send-pages" type="checkbox" name="onesignal_auto_send_pages"
                  <?php echo (!empty($settings['notification_on_page'])) ? 'checked' : ''; ?>>
           <span class="checkbox"></span>
-          Automatically send notifications when a page is published or updated
+          Automatically send notifications when a page is published
         </label>
       </div>
 

--- a/v3/onesignal-admin/onesignal-admin.php
+++ b/v3/onesignal-admin/onesignal-admin.php
@@ -104,7 +104,7 @@ function onesignal_admin_page()
     }
     ?>
     <form method="post">
-      <label for="appid">OneSignal App ID</label>
+      <label for="appid">OneSignal App ID HELLLO</label>
       <div class="input-with-icon">
         <input type="text" id="appid" name="onesignal_app_id"
               value="<?php echo esc_attr(get_option('OneSignalWPSetting')['app_id'] ?? ''); ?>" />

--- a/v3/onesignal-metabox/onesignal-metabox.php
+++ b/v3/onesignal-metabox/onesignal-metabox.php
@@ -59,16 +59,20 @@ function onesignal_metabox($post)
        <?php
        // Determine if this is a new post (never published)
        $is_new_post = ($post->post_status !== 'publish' || empty($post->post_date_gmt));
+       $post_type = $post->post_type;
        if ($is_new_post) {
-           // First time publish: use global setting
-           $os_update_checked = (get_option('OneSignalWPSetting')['notification_on_post'] ?? 0) == 1;
+           if ($post_type === 'page') {
+               $os_update_checked = (get_option('OneSignalWPSetting')['notification_on_page'] ?? 0) == 1;
+           } else {
+               $os_update_checked = (get_option('OneSignalWPSetting')['notification_on_post'] ?? 0) == 1;
+           }
        } else {
            // Already published: always unchecked
            $os_update_checked = false;
        }
        echo $os_update_checked ? 'checked' : '';
        ?>>
-Send notification when post is published or updated
+Send notification when <?php echo $post_type === 'page' ? 'page' : 'post'; ?> is published
 </label>
   <div id="os_options">
     <label for="os_segment">Send to segment</label>

--- a/v3/onesignal-metabox/onesignal-metabox.php
+++ b/v3/onesignal-metabox/onesignal-metabox.php
@@ -57,10 +57,15 @@ function onesignal_metabox($post)
   <label for="os_update">
   <input type="checkbox" name="os_update" id="os_update"
        <?php
-       $os_update_checked = isset($os_meta['os_update'])
-           ? $os_meta['os_update'] === 'on'
-           : (get_option('OneSignalWPSetting')['notification_on_post'] ?? 0) == 1;
-
+       // Determine if this is a new post (never published)
+       $is_new_post = ($post->post_status !== 'publish' || empty($post->post_date_gmt));
+       if ($is_new_post) {
+           // First time publish: use global setting
+           $os_update_checked = (get_option('OneSignalWPSetting')['notification_on_post'] ?? 0) == 1;
+       } else {
+           // Already published: always unchecked
+           $os_update_checked = false;
+       }
        echo $os_update_checked ? 'checked' : '';
        ?>>
 Send notification when post is published or updated


### PR DESCRIPTION
#348 visually unchecked the box on post, but a page refresh results in the checkbox being checked again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/366)
<!-- Reviewable:end -->
