### PR TITLE
feat: distinguish between sending notifications on publish vs update

### DIFF
--- a/v3/onesignal-admin/onesignal-admin.js
+++ b/v3/onesignal-admin/onesignal-admin.js
@@ -33,6 +33,8 @@ window.addEventListener("DOMContentLoaded", () => {
   const customPostTypesInput = document.querySelector("#custom-post-types");
   const notificationOnPostFromPluginCheckbox = document.querySelector("#notification-on-post-from-plugin");
   const notificationOnPageCheckbox = document.querySelector("#auto-send-pages");
+  const autoSendPostUpdateCheckbox = document.querySelector("#auto-send-post-update");
+  const autoSendPageUpdateCheckbox = document.querySelector("#auto-send-page-update");
 
   const haveAllAdminInputsLoaded = appIdInput &&
     apiKeyInput &&
@@ -42,7 +44,9 @@ window.addEventListener("DOMContentLoaded", () => {
     saveButton &&
     customPostTypesInput &&
     notificationOnPostFromPluginCheckbox &&
-    notificationOnPageCheckbox;
+    notificationOnPageCheckbox &&
+    autoSendPostUpdateCheckbox &&
+    autoSendPageUpdateCheckbox;
 
   if (haveAllAdminInputsLoaded) {
     const initialAppId = appIdInput.value;
@@ -53,6 +57,8 @@ window.addEventListener("DOMContentLoaded", () => {
     const initialCustomPostTypes = customPostTypesInput.value;
     const initialNotificationOnPostFromPlugin = notificationOnPostFromPluginCheckbox.checked;
     const initialNotificationOnPage = notificationOnPageCheckbox.checked;
+    const initialAutoSendPostUpdate = autoSendPostUpdateCheckbox.checked;
+    const initialAutoSendPageUpdate = autoSendPageUpdateCheckbox.checked;
 
     function isValidUUID(uuid) {
       const uuidRegex =
@@ -85,6 +91,8 @@ window.addEventListener("DOMContentLoaded", () => {
       const customPostTypesChanged = customPostTypesInput.value !== initialCustomPostTypes;
       const notificationOnPostFromPluginChanged = notificationOnPostFromPluginCheckbox.checked !== initialNotificationOnPostFromPlugin;
       const notificationOnPageChanged = notificationOnPageCheckbox.checked !== initialNotificationOnPage;
+      const autoSendPostUpdateChanged = autoSendPostUpdateCheckbox.checked !== initialAutoSendPostUpdate;
+      const autoSendPageUpdateChanged = autoSendPageUpdateCheckbox.checked !== initialAutoSendPageUpdate;
 
       return appIdChanged ||
         apiKeyChanged ||
@@ -93,7 +101,9 @@ window.addEventListener("DOMContentLoaded", () => {
         utmChanged ||
         customPostTypesChanged ||
         notificationOnPostFromPluginChanged ||
-        notificationOnPageChanged;
+        notificationOnPageChanged ||
+        autoSendPostUpdateChanged ||
+        autoSendPageUpdateChanged;
     }
 
     function toggleSaveButton() {
@@ -124,6 +134,8 @@ window.addEventListener("DOMContentLoaded", () => {
     customPostTypesInput.addEventListener("input", toggleSaveButton);
     notificationOnPostFromPluginCheckbox.addEventListener("change", toggleSaveButton);
     notificationOnPageCheckbox.addEventListener("change", toggleSaveButton);
+    autoSendPostUpdateCheckbox.addEventListener("change", toggleSaveButton);
+    autoSendPageUpdateCheckbox.addEventListener("change", toggleSaveButton);
 
     // Initial state on page load
     toggleSaveButton();

--- a/v3/onesignal-admin/onesignal-admin.php
+++ b/v3/onesignal-admin/onesignal-admin.php
@@ -63,6 +63,14 @@ if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST') 
     $send_to_mobile = isset($_POST['onesignal_send_to_mobile']) ? 1 : 0;
     $onesignal_settings['send_to_mobile_platforms'] = $send_to_mobile;
 
+    // Save the auto send notifications setting for post updates
+    $auto_send_post_update = isset($_POST['onesignal_auto_send_post_update']) ? 1 : 0;
+    $onesignal_settings['notification_on_post_update'] = $auto_send_post_update;
+
+    // Save the auto send notifications setting for page updates
+    $auto_send_page_update = isset($_POST['onesignal_auto_send_page_update']) ? 1 : 0;
+    $onesignal_settings['notification_on_page_update'] = $auto_send_page_update;
+
     // Update with autoload set to 'no' to prevent caching issues
     update_option('OneSignalWPSetting', $onesignal_settings, 'no');
 
@@ -77,7 +85,9 @@ function onesignal_get_default_settings() {
         'notification_on_post' => 0,
         'notification_on_page' => 0,
         'notification_on_post_from_plugin' => 0,
-        'send_to_mobile_platforms' => 0
+        'send_to_mobile_platforms' => 0,
+        'notification_on_post_update' => 0,
+        'notification_on_page_update' => 0
     );
 }
 
@@ -207,13 +217,23 @@ function onesignal_admin_page()
         <input id="custom-post-types"type="text" placeholder="forum,reply,topic  (comma separated, no spaces between commas)" name="allowed_custom_post_types" value="<?php echo esc_attr($customPostTypes); ?>">
       </div>
 
-      <!-- Auto Send Checkbox -->
+      <!-- Auto Send For Posts Checkbox -->
       <div class="checkbox-wrapper auto-send">
         <label for="auto-send">
           <input id="auto-send" type="checkbox" name="onesignal_auto_send"
                  <?php echo (!empty($settings['notification_on_post'])) ? 'checked' : ''; ?>>
           <span class="checkbox"></span>
           Automatically send notifications when a post is published
+        </label>
+      </div>
+
+      <!-- Auto Send for Post Updates Checkbox -->
+      <div class="checkbox-wrapper auto-send-post-update">
+        <label for="auto-send-post-update">
+          <input id="auto-send-post-update" type="checkbox" name="onesignal_auto_send_post_update"
+                 <?php echo (!empty($settings['notification_on_post_update'])) ? 'checked' : ''; ?>>
+          <span class="checkbox"></span>
+          Automatically send notifications when a post is updated
         </label>
       </div>
 
@@ -224,6 +244,16 @@ function onesignal_admin_page()
                  <?php echo (!empty($settings['notification_on_page'])) ? 'checked' : ''; ?>>
           <span class="checkbox"></span>
           Automatically send notifications when a page is published
+        </label>
+      </div>
+
+      <!-- Auto Send for Page Updates Checkbox -->
+      <div class="checkbox-wrapper auto-send-page-update">
+        <label for="auto-send-page-update">
+          <input id="auto-send-page-update" type="checkbox" name="onesignal_auto_send_page_update"
+                 <?php echo (!empty($settings['notification_on_page_update'])) ? 'checked' : ''; ?>>
+          <span class="checkbox"></span>
+          Automatically send notifications when a page is updated
         </label>
       </div>
 

--- a/v3/onesignal-metabox/onesignal-metabox.php
+++ b/v3/onesignal-metabox/onesignal-metabox.php
@@ -69,14 +69,14 @@ function onesignal_metabox($post)
        } else {
            // Already published: use update settings
            if ($post_type === 'page') {
-               $os_update_checked = (get_option('OneSignalWPSetting')['notification_on_page'] ?? 0) == 1;
+               $os_update_checked = (get_option('OneSignalWPSetting')['notification_on_page_update'] ?? 0) == 1;
            } else {
                $os_update_checked = (get_option('OneSignalWPSetting')['notification_on_post_update'] ?? 0) == 1;
            }
        }
        echo $os_update_checked ? 'checked' : '';
        ?>>
-Send notification when <?php echo $post_type === 'page' ? 'page' : 'post'; ?> is <?php echo ($is_new_post || $post_type === 'page') ? 'published' : 'updated'; ?>
+Send notification when <?php echo $post_type === 'page' ? 'page' : 'post'; ?> is <?php echo $is_new_post ? 'published' : 'updated'; ?>
 </label>
   <div id="os_options">
     <label for="os_segment">Send to segment</label>

--- a/v3/onesignal-metabox/onesignal-metabox.php
+++ b/v3/onesignal-metabox/onesignal-metabox.php
@@ -67,12 +67,16 @@ function onesignal_metabox($post)
                $os_update_checked = (get_option('OneSignalWPSetting')['notification_on_post'] ?? 0) == 1;
            }
        } else {
-           // Already published: always unchecked
-           $os_update_checked = false;
+           // Already published: use update settings
+           if ($post_type === 'page') {
+               $os_update_checked = (get_option('OneSignalWPSetting')['notification_on_page'] ?? 0) == 1;
+           } else {
+               $os_update_checked = (get_option('OneSignalWPSetting')['notification_on_post_update'] ?? 0) == 1;
+           }
        }
        echo $os_update_checked ? 'checked' : '';
        ?>>
-Send notification when <?php echo $post_type === 'page' ? 'page' : 'post'; ?> is published
+Send notification when <?php echo $post_type === 'page' ? 'page' : 'post'; ?> is <?php echo ($is_new_post || $post_type === 'page') ? 'published' : 'updated'; ?>
 </label>
   <div id="os_options">
     <label for="os_segment">Send to segment</label>


### PR DESCRIPTION
## Description

Generally speaking, plugin consumers only want to notify their subscribers when a new post, or even some new pages, are published for the first time. It's likely not the case that they will want subscribers notified if a post/page is edited e.g. correcting typos.

This PR separates these concerns into their own toggles on the plugin admin panel. This way, users have more fine-grained controls over the default notification settings for each of these content types under different scenarios. The motivation for this change is to help avoid scenarios where users unintentionally send out notifications because publishing & updating content are treated the same way.

### Details
  
- Add toggle to automatically send notifications when a post is updated
  - This affects the default state of the "Send Notification" checkbox after a post is already published
- Add toggle to automatically send notifications when a page is updated
  - This affects the default state of the "Send Notification" checkbox after a page is already published
- Handle state tracking for new checkboxes and update form validation when saving admin settings

## Demo
https://github.com/user-attachments/assets/4e566dcf-30e2-4133-8b80-d639ad4383e3

### References
- https://wordpress.org/support/topic/too-many-notifications-a-suggestion/
- https://wordpress.org/support/topic/latest-version-of-plugin-sending-notifications-on-updates/
- https://github.com/OneSignal/OneSignal-WordPress-Plugin/pull/366#issuecomment-3114813807

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-WordPress-Plugin/373)
<!-- Reviewable:end -->
